### PR TITLE
Add multind and prox functions for {less,greater} than or equal to, and real-value constraint

### DIFF
--- a/src/iter/prox.c
+++ b/src/iter/prox.c
@@ -473,3 +473,26 @@ const struct operator_p_s* prox_greq_create(unsigned int N, const long dims[N], 
 {
 	return prox_ineq_create(N, dims, b, true);
 }
+
+struct prox_rvc_data {
+	long size;
+};
+
+static void prox_rvc_apply(const void* _data, float mu, complex float* dst, const complex float* src)
+{
+	UNUSED(mu);
+	struct prox_rvc_data* pdata = (struct prox_rvc_data*)_data;
+	md_zreal(1, MD_DIMS(pdata->size), dst, src);
+}
+
+static void prox_rvc_del(const void* _data)
+{
+	free((void*)_data);
+}
+
+const struct operator_p_s* prox_rvc_create(unsigned int N, const long dims[N])
+{
+	struct prox_rvc_data* pdata = xmalloc(sizeof(struct prox_rvc_data));
+	pdata->size = md_calc_size(N, dims);
+	return operator_p_create(N, dims, N, dims, pdata, prox_rvc_apply, prox_rvc_del);
+}

--- a/src/iter/prox.c
+++ b/src/iter/prox.c
@@ -464,11 +464,19 @@ static const struct operator_p_s* prox_ineq_create(unsigned int N, const long di
 }
 
 
+/*
+ * Proximal function for less than or equal to:
+ * f(z) = 1{z <= b}
+ */
 const struct operator_p_s* prox_lesseq_create(unsigned int N, const long dims[N], const complex float* b)
 {
 	return prox_ineq_create(N, dims, b, false);
 }
 
+/*
+ * Proximal function for greater than or equal to:
+ * f(z) = 1{z >= b}
+ */
 const struct operator_p_s* prox_greq_create(unsigned int N, const long dims[N], const complex float* b)
 {
 	return prox_ineq_create(N, dims, b, true);
@@ -490,6 +498,9 @@ static void prox_rvc_del(const void* _data)
 	free((void*)_data);
 }
 
+/*
+ * Proximal function for real-value constraint
+ */
 const struct operator_p_s* prox_rvc_create(unsigned int N, const long dims[N])
 {
 	struct prox_rvc_data* pdata = xmalloc(sizeof(struct prox_rvc_data));

--- a/src/iter/prox.c
+++ b/src/iter/prox.c
@@ -1,9 +1,9 @@
-/* Copyright 2014. The Regents of the University of California.
+/* Copyright 2014-2015. The Regents of the University of California.
  * All rights reserved. Use of this source code is governed by 
  * a BSD-style license which can be found in the LICENSE file.
  *
  * Authors: 
- * 2014	Jonathan Tamir <jtamir@eecs.berkeley.edu>
+ * 2014-2015	Jonathan Tamir <jtamir@eecs.berkeley.edu>
  */
 
 #include <complex.h>

--- a/src/iter/prox.h
+++ b/src/iter/prox.h
@@ -16,8 +16,9 @@ extern const struct operator_p_s* prox_normaleq_create(const struct linop_s* op,
 extern const struct operator_p_s* prox_leastsquares_create(unsigned int N, const long dims[__VLA(N)], float lambda, const _Complex float* y);
 extern const struct operator_p_s* prox_l2ball_create(unsigned int N, const long dims[__VLA(N)], float eps, const _Complex float* center);
 extern const struct operator_p_s* prox_zero_create(unsigned int N, const long dims[__VLA(N)]);
-
 extern const struct operator_p_s* prox_lineq_create(const struct linop_s* op, const _Complex float* y);
+extern const struct operator_p_s* prox_lesseq_create(unsigned int N, const long dims[__VLA(N)], const _Complex float* b);
+extern const struct operator_p_s* prox_greq_create(unsigned int N, const long dims[__VLA(N)], const _Complex float* b);
 
 #include "misc/cppwrap.h"
 #endif

--- a/src/iter/prox.h
+++ b/src/iter/prox.h
@@ -19,6 +19,7 @@ extern const struct operator_p_s* prox_zero_create(unsigned int N, const long di
 extern const struct operator_p_s* prox_lineq_create(const struct linop_s* op, const _Complex float* y);
 extern const struct operator_p_s* prox_lesseq_create(unsigned int N, const long dims[__VLA(N)], const _Complex float* b);
 extern const struct operator_p_s* prox_greq_create(unsigned int N, const long dims[__VLA(N)], const _Complex float* b);
+extern const struct operator_p_s* prox_rvc_create(unsigned int N, const long dims[__VLA(N)]);
 
 #include "misc/cppwrap.h"
 #endif

--- a/src/num/flpmath.c
+++ b/src/num/flpmath.c
@@ -1816,6 +1816,56 @@ void md_slessequal(unsigned int D, const long dims[D], float* optr, const float*
 
 
 /**
+ * Elementwise greater than or equal to (with strides)
+ * 
+ * optr = (iptr1 => iptr2)
+ */
+void md_greatequal2(unsigned int D, const long dims[D], const long ostr[D], float* optr, const long istr1[D], const float* iptr1, const long istr2[D], const float* iptr2)
+{
+	MAKE_3OP(ge, D, dims, ostr, optr, istr1, iptr1, istr2, iptr2);
+}
+
+
+
+/**
+ * Elementwise greater than or equal to (without strides)
+ * 
+ * optr = (iptr1 >= iptr2)
+ */
+void md_greatequal(unsigned int D, const long dims[D], float* optr, const float* iptr1, const float* iptr2)
+{
+	make_3op_simple(md_greatequal2, D, dims, optr, iptr1, iptr2);
+}
+
+
+
+/**
+ * Elementwise greater than or equal to scalar (with strides)
+ * 
+ * optr = (iptr >= val)
+ */
+void md_sgreatequal2(unsigned int D, const long dims[D], const long ostr[D], float* optr, const long istr[D], const float* iptr, float val)
+{
+	make_3op_scalar(md_greatequal2, D, dims, ostr, optr, istr, iptr, val);
+}
+
+
+
+/**
+ * Elementwise greater than or equal to scalar (without strides)
+ * 
+ * optr = (iptr >= val)
+ */
+void md_sgreatequal(unsigned int D, const long dims[D], float* optr, const float* iptr, float val)
+{
+	long strs[D];
+	md_calc_strides(D, strs, dims, FL_SIZE);
+	md_sgreatequal2(D, dims, strs, optr, strs, iptr, val);
+}
+
+
+
+/**
  * Extract unit-norm complex exponentials from complex arrays (with strides)
  * 
  * optr = iptr / abs(iptr)
@@ -2725,6 +2775,39 @@ void md_smin(unsigned int D, const long dim[D], float* optr, const float* iptr, 
 	long str[D];
  	md_calc_strides(D, str, dim, FL_SIZE);
 	md_smin2(D, dim, str, optr, str, iptr, val);
+}
+
+
+
+/**
+ *  Elementwise maximum of input and scalar (with strides)
+ *
+ *  optr = max(val, iptr)
+ */
+void md_smax2(unsigned int D, const long dim[D], const long ostr[D], float* optr, const long istr[D], const float* iptr, float val)
+{
+#if 0
+	float* tmp = md_alloc_sameplace(D, dim, FL_SIZE, iptr);
+	md_sgreatequal2(D, dim, ostr, tmp, istr, iptr, val);
+	md_mul2(D, dim, ostr, optr, istr, iptr, istr, tmp);
+	md_free(tmp);
+#else
+	make_3op_scalar(md_max2, D, dim, ostr, optr, istr, iptr, val);
+#endif
+}
+
+
+
+/**
+ *  Elementwise minimum of input and scalar (without strides)
+ *
+ *  optr = max(val, iptr)
+ */
+void md_smax(unsigned int D, const long dim[D], float* optr, const float* iptr, float val)
+{
+	long str[D];
+ 	md_calc_strides(D, str, dim, FL_SIZE);
+	md_smax2(D, dim, str, optr, str, iptr, val);
 }
 
 

--- a/src/num/flpmath.c
+++ b/src/num/flpmath.c
@@ -1,4 +1,4 @@
-/* Copyright 2013-2014 The Regents of the University of California.
+/* Copyright 2013-2015 The Regents of the University of California.
  * All rights reserved. Use of this source code is governed by 
  * a BSD-style license which can be found in the LICENSE file.
  *
@@ -6,7 +6,7 @@
  * 2012-2014 Martin Uecker <uecker@eecs.berkeley.edu>
  * 2013 Dara Bahri <dbahri123@gmail.com>
  * 2014 Frank Ong <frankong@berkeley.edu>
- * 2014 Jonathan Tamir <jtamir@eecs.berkeley.edu>
+ * 2014-2015 Jonathan Tamir <jtamir@eecs.berkeley.edu>
  *
  *
  * Operations on arrays of complex single-precision floating

--- a/src/num/flpmath.h
+++ b/src/num/flpmath.h
@@ -177,6 +177,11 @@ extern void md_lessequal2(unsigned int D, const long dim[__VLA(D)], const long o
 extern void md_slessequal(unsigned int D, const long dim[__VLA(D)], float* optr, const float* iptr, float val);
 extern void md_slessequal2(unsigned int D, const long dim[__VLA(D)], const long ostr[__VLA(D)], float* optr, const long istr[__VLA(D)], const float* iptr, float val);
 
+extern void md_greatequal(unsigned int D, const long dim[__VLA(D)], float* optr, const float* iptr1, const float* iptr2);
+extern void md_greatequal2(unsigned int D, const long dim[__VLA(D)], const long ostr[__VLA(D)], float* optr, const long istr1[__VLA(D)], const float* iptr1, const long istr2[__VLA(D)], const float* iptr2);
+extern void md_sgreatequal(unsigned int D, const long dim[__VLA(D)], float* optr, const float* iptr, float val);
+extern void md_sgreatequal2(unsigned int D, const long dim[__VLA(D)], const long ostr[__VLA(D)], float* optr, const long istr[__VLA(D)], const float* iptr, float val);
+
 extern float md_znorm2(unsigned int D, const long dim[__VLA(D)], const long str[__VLA(D)], const _Complex float* ptr);
 extern float md_znorm(unsigned int D, const long dim[__VLA(D)], const _Complex float* ptr);
 extern _Complex float md_zscalar2(unsigned int D, const long dim[__VLA(D)], const long str1[__VLA(D)], const _Complex float* ptr1, const long str2[__VLA(D)], const _Complex float* ptr2);
@@ -238,7 +243,8 @@ extern void md_zfill(unsigned int D, const long dim[__VLA(D)], _Complex float* p
 
 extern void md_smin2(unsigned int D, const long dim[__VLA(D)], const long ostr[__VLA(D)], float* optr, const long istr[__VLA(D)], const float* iptr, float val);
 extern void md_smin(unsigned int D, const long dim[__VLA(D)], float* optr, const float* iptr, float val);
-
+extern void md_smax2(unsigned int D, const long dim[__VLA(D)], const long ostr[__VLA(D)], float* optr, const long istr[__VLA(D)], const float* iptr, float val);
+extern void md_smax(unsigned int D, const long dim[__VLA(D)], float* optr, const float* iptr, float val);
 
 extern void md_fdiff2(unsigned int D, const long dims[__VLA(D)], unsigned int d, const long ostr[__VLA(D)], float* out, const long istr[__VLA(D)], const float* in);
 extern void md_fdiff(unsigned int D, const long dims[__VLA(D)], unsigned int d, float* out, const float* in);

--- a/src/num/gpukrnls.cu
+++ b/src/num/gpukrnls.cu
@@ -622,6 +622,20 @@ extern "C" void cuda_le(long N, float* dst, const float* src1, const float* src2
 	kern_le<<<gridsize(N), blocksize(N)>>>(N, dst, src1, src2);
 }
 
+__global__ void kern_ge(int N, float* dst, const float* src1, const float* src2)
+{
+	int start = threadIdx.x + blockDim.x * blockIdx.x;
+	int stride = blockDim.x * gridDim.x;
+
+	for (int i = start; i < N; i += stride)
+		dst[i] = (src1[i] >= src2[i]);
+}
+
+extern "C" void cuda_ge(long N, float* dst, const float* src1, const float* src2)
+{
+	kern_ge<<<gridsize(N), blocksize(N)>>>(N, dst, src1, src2);
+}
+
 __device__ cuFloatComplex cuDouble2Float(cuDoubleComplex x)
 {
 	return make_cuFloatComplex(cuCreal(x), cuCimag(x));

--- a/src/num/gpukrnls.cu
+++ b/src/num/gpukrnls.cu
@@ -1,9 +1,10 @@
-/* Copyright 2013. The Regents of the University of California.
+/* Copyright 2013-2015. The Regents of the University of California.
  * All rights reserved. Use of this source code is governed by 
  * a BSD-style license which can be found in the LICENSE file.
  *
  * Authors:
  * 2012-03-24 Martin Uecker <uecker@eecs.berkeley.edu>
+ * 2015 Jonathan Tamir <jtamir@eecs.berkeley.edu>
  *
  * 
  * This file defines basic operations on vectors of floats/complex floats

--- a/src/num/gpukrnls.h
+++ b/src/num/gpukrnls.h
@@ -40,6 +40,7 @@ extern void cuda_zreal(long N, _Complex float* dst, const _Complex float* src);
 extern void cuda_zcmp(long N, _Complex float* dst, const _Complex float* src1, const _Complex float* src2);
 extern void cuda_zdiv_reg(long N, _Complex float* dst, const _Complex float* src1, const _Complex float* src2, _Complex float lambda);
 extern void cuda_le(long N, float* dst, const float* src1, const float* src2);
+extern void cuda_ge(long N, float* dst, const float* src1, const float* src2);
 extern void cuda_zfftmod(long N, _Complex float* dst, const _Complex float* src, unsigned int n, _Bool inv, double phase);
 extern void cuda_max(long N, float* dst, const float* src1, const float* src2);
 extern void cuda_min(long N, float* dst, const float* src1, const float* src2);

--- a/src/num/gpuops.c
+++ b/src/num/gpuops.c
@@ -5,6 +5,7 @@
  * Authors: 
  * 2012-2015	Martin Uecker <uecker@eecs.berkeley.edu>
  * 2014 	Joseph Y Cheng <jycheng@stanford.edu>
+ * 2015	Jonathan Tamir <jtamir@eecs.berkeley.edu>
  *
  * 
  * CUDA support functions. The file exports gpu_ops of type struct vec_ops

--- a/src/num/gpuops.c
+++ b/src/num/gpuops.c
@@ -500,6 +500,7 @@ const struct vec_ops gpu_ops = {
 	.sqrt = cuda_sqrt,
 
 	.le = cuda_le,
+	.ge = cuda_ge,
 
 	.zmul = cuda_zmul,
 	.zdiv = cuda_zdiv,

--- a/src/num/vecops.c
+++ b/src/num/vecops.c
@@ -5,7 +5,7 @@
  * Authors:
  * 2011, 2014-2015 Martin Uecker <uecker@eecs.berkeley.edu>
  * 2014 Frank Ong <frankong@berkeley.edu>
- * 2014 Jonathan Tamir <jtamir@eecs.berkeley.edu>
+ * 2014-2015 Jonathan Tamir <jtamir@eecs.berkeley.edu>
  *
  *
  * This file defines basic operations on vectors of floats/complex floats

--- a/src/num/vecops.c
+++ b/src/num/vecops.c
@@ -330,6 +330,12 @@ static void vec_le(long N, float* dst, const float* src1, const float* src2)
 		dst[i] = (src1[i] <= src2[i]);
 }
 
+static void vec_ge(long N, float* dst, const float* src1, const float* src2)
+{
+	for (long i = 0; i < N; i++)
+		dst[i] = (src1[i] >= src2[i]);
+}
+
 /**
  * Step (1) of soft thesholding, y = ST(x, lambda).
  * Only computes the residual, resid = MAX( (abs(x) - lambda)/abs(x)), 0 )
@@ -464,6 +470,7 @@ const struct vec_ops cpu_ops = {
 	.sqrt = vec_sqrt,
 
 	.le = vec_le,
+	.ge = vec_ge,
 
 	.zmul = zmul,
 	.zdiv = zdiv,

--- a/src/num/vecops.h
+++ b/src/num/vecops.h
@@ -28,6 +28,7 @@ struct vec_ops {
 	void (*sqrt)(long N, float* dst, const float* src);
 
 	void (*le)(long N, float* dst, const float* src1, const float* src2);
+	void (*ge)(long N, float* dst, const float* src1, const float* src2);
 
 	void (*add)(long N, float* dst, const float* src1, const float* src2);
 	void (*sub)(long N, float* dst, const float* src1, const float* src2);


### PR DESCRIPTION
There is some code duplication with real-value constraint and identity operators - we have versions for ops and versions for linops. One option is to implement them only once under `num/ops.c`.