### PR TITLE
Soft-Weighting Singular Vectors for Robust Eigenmap Estimation.

### DIFF
--- a/src/calib/calib.c
+++ b/src/calib/calib.c
@@ -35,6 +35,7 @@
 
 #include "calib/calmat.h"
 #include "calib/cc.h"
+#include "calib/softweight.h"
 
 #include "calib.h"
 
@@ -42,7 +43,7 @@
 #include "calib/calibcu.h"
 #endif
 
-#if 0
+#if 1
 #define CALMAT_SVD
 #endif
 
@@ -506,6 +507,9 @@ void compute_kernels(const struct ecalib_conf* conf, long nskerns_dims[5], compl
 #ifdef CALMAT_SVD
 	calmat_svd(conf->kdims, N, vec, val, caldims, caldata);
 
+        if (conf->weighting)
+            soft_weight_singular_vectors(N, conf->kdims, caldims, val);
+
 	for (int i = 0; i < N; i++)
 		for (int j = 0; j < N; j++) 
 #ifndef FLIP
@@ -524,7 +528,10 @@ void compute_kernels(const struct ecalib_conf* conf, long nskerns_dims[5], compl
 	lapack_eig(N, tmp_val, vec);
 
 	for (int i = 0; i < N; i++)
-		val[i] = sqrtf(tmp_val[N - 1 - i]);
+		val[i] = sqrtf(tmp_val[N - 1 - i]); // val holds the singular values (Or square roots of the evals)
+
+        if (conf->weighting)
+            soft_weight_singular_vectors(N, conf->kdims, caldims, val);
 
 	for (int i = 0; i < N; i++)
 		for (int j = 0; j < N; j++) 

--- a/src/calib/calib.c
+++ b/src/calib/calib.c
@@ -5,6 +5,7 @@
  * Authors:
  * 2012-2015 Martin Uecker <uecker@eecs.berkeley.edu>
  * 2013 Dara Bahri <dbahri123@gmail.com>
+ * 2015 Siddharth Iyer <sid8795@gmail.com>
  *
  *
  * Uecker M, Lai P, Murphy MJ, Virtue P, Elad M, Pauly JM, Vasanawala SS, Lustig M.
@@ -509,13 +510,6 @@ void compute_kernels(const struct ecalib_conf* conf, long nskerns_dims[5], compl
 
         if (conf->weighting)
             soft_weight_singular_vectors(N, conf->kdims, caldims, val);
-
-        //TODO: REMOVE.
-        printf("VAL\n");
-        for (int idx = 0; idx < N; idx++) {
-            val[idx] = val[idx] * val[idx];
-            printf("S[%d]: %f\n", idx, val[idx]);
-        }
 
 	for (int i = 0; i < N; i++)
 		for (int j = 0; j < N; j++) 

--- a/src/calib/calib.c
+++ b/src/calib/calib.c
@@ -44,7 +44,7 @@
 #include "calib/calibcu.h"
 #endif
 
-#if 1
+#if 0
 #define CALMAT_SVD
 #endif
 
@@ -509,7 +509,7 @@ void compute_kernels(const struct ecalib_conf* conf, long nskerns_dims[5], compl
 	calmat_svd(conf->kdims, N, vec, val, caldims, caldata);
 
         if (conf->weighting)
-            soft_weight_singular_vectors(N, conf->kdims, caldims, val);
+            soft_weight_singular_vectors(N, conf->kdims, caldims, val, val);
 
 	for (int i = 0; i < N; i++)
 		for (int j = 0; j < N; j++) 
@@ -532,7 +532,7 @@ void compute_kernels(const struct ecalib_conf* conf, long nskerns_dims[5], compl
 		val[i] = sqrtf(tmp_val[N - 1 - i]); // val holds the singular values (Or square roots of the evals)
 
         if (conf->weighting)
-            soft_weight_singular_vectors(N, conf->kdims, caldims, val);
+            soft_weight_singular_vectors(N, conf->kdims, caldims, val, val);
 
 	for (int i = 0; i < N; i++)
 		for (int j = 0; j < N; j++) 

--- a/src/calib/calib.c
+++ b/src/calib/calib.c
@@ -510,6 +510,13 @@ void compute_kernels(const struct ecalib_conf* conf, long nskerns_dims[5], compl
         if (conf->weighting)
             soft_weight_singular_vectors(N, conf->kdims, caldims, val);
 
+        //TODO: REMOVE.
+        printf("VAL\n");
+        for (int idx = 0; idx < N; idx++) {
+            val[idx] = val[idx] * val[idx];
+            printf("S[%d]: %f\n", idx, val[idx]);
+        }
+
 	for (int i = 0; i < N; i++)
 		for (int j = 0; j < N; j++) 
 #ifndef FLIP

--- a/src/calib/estvar.c
+++ b/src/calib/estvar.c
@@ -238,7 +238,7 @@ static float estimate_noise_variance(long L, float* S, float* E)
         t += ((float)S[idx])/((float)E[idx]);
     }
 
-    return ((float)(s * s) * (t * t)/(L * L))/1.1; //Scaling down since it works well in practice.
+    return ((float)(s * s) * (t * t)/(L * L))/1.21; //Scaling down since it works well in practice.
 
 }
 

--- a/src/calib/softweight.c
+++ b/src/calib/softweight.c
@@ -1,0 +1,99 @@
+/* Copyright 2015. The Regents of the University of California.
+ * All rights reserved. Use of this source code is governed by 
+ * a BSD-style license which can be found in the LICENSE file.
+ *
+ * Authors: 
+ * 2015 Siddharth Iyer <sid8795@gmail.com>
+ */
+
+#include <assert.h>
+#include <complex.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "num/rand.h"
+#include "num/multind.h"
+#include "num/lapack.h"
+
+#include "misc/debug.h"
+
+#include "calib/estvar.h"
+
+#include "softweight.h"
+
+static float divergence(long N, float S[N], long calmat_dims[2], float lambda) {
+
+    int idx, jdx;
+
+    float div = 0;
+    float abs_diff_bw_calmat_dims = abs(calmat_dims[0] - calmat_dims[1]);
+
+    float s, s1, s2, t;
+    for (idx = 0; idx < N; idx ++) {
+        s  = S[idx];
+        t  = 1 - lambda/s;
+        s1 = (s > lambda ? 1: 0) + 2 * abs_diff_bw_calmat_dims * (t > 0? t: 0);
+        s2 = 0;
+        for (jdx = 0; jdx < N; jdx++) {
+            if (idx == jdx)
+                continue;
+            t = s - lambda;
+            s2 += s * (t > 0? t: 0)/(s * s - S[jdx] * S[jdx]);
+        }
+        div += s1 + 4 * s2;
+    }
+
+    return div;
+
+}
+
+extern void soft_weight_singular_vectors(long N, long kernel_dims[3], long calreg_dims[4], float S[N]) {
+
+    int idx = 0, jdx = 0;
+
+    float t;
+    float variance = estvar_sv(N, S, kernel_dims, calreg_dims);
+
+    long calmat_dims[2] = {(calreg_dims[0] - kernel_dims[0] + 1) * (calreg_dims[1] - kernel_dims[1] + 1) * 
+                (calreg_dims[2] - kernel_dims[2] + 1),
+            kernel_dims[0] * kernel_dims[1] * kernel_dims[2] * calreg_dims[3]};
+
+    float Y = calmat_dims[0] * calmat_dims[1] * variance;
+    float G = 0;
+    for (jdx = 0; jdx < N; jdx++) {
+        G += S[jdx] * S[jdx];
+    }
+
+    float lambda = S[0];
+    float testMSE = 0;
+    float MSE = -Y + G + variance * divergence(N, S, calmat_dims, lambda);
+
+    for (idx = 1; idx < N; idx++) {
+
+        G = 0;
+        for (jdx = 0; jdx < N; jdx++) {
+            t = S[jdx];
+            G += (t > lambda ? lambda * lambda : t * t);
+        }
+
+        testMSE = -Y + G + variance * divergence(N, S, calmat_dims, S[idx]);
+
+        if (testMSE <= MSE) {
+            MSE    = testMSE;
+            lambda = S[idx];
+        }
+
+    }
+
+    //TODO : DEBUG
+    printf("Lambda: %f\n", lambda);
+
+    for (int idx = 0; idx < N; idx++) {
+        t = (S[idx] - lambda)/S[idx];
+        S[idx] = ((!isnan(t) && t > 0)? t: 0);
+    }
+
+}

--- a/src/calib/softweight.c
+++ b/src/calib/softweight.c
@@ -64,26 +64,35 @@ extern void soft_weight_singular_vectors(long N, long kernel_dims[3], long calre
     float Y = calmat_dims[0] * calmat_dims[1] * variance;
     float G = 0;
     for (jdx = 0; jdx < N; jdx++) {
+        //TODO: Delete print
+        printf("S[%d]: %f\n", jdx, S[jdx]);
         G += S[jdx] * S[jdx];
     }
 
     float lambda = S[0];
     float testMSE = 0;
+    float testLambda = 0;
     float MSE = -Y + G + variance * divergence(N, S, calmat_dims, lambda);
+
+    //TODO: REmove
+    printf("MSE[%d]: %f\n", idx, MSE);
 
     for (idx = 1; idx < N; idx++) {
 
         G = 0;
+        testLambda = S[idx];
         for (jdx = 0; jdx < N; jdx++) {
             t = S[jdx];
-            G += (t > lambda ? lambda * lambda : t * t);
+            G += (t < testLambda? t * t : testLambda * testLambda);
         }
 
-        testMSE = -Y + G + variance * divergence(N, S, calmat_dims, S[idx]);
+        testMSE = -Y + G + variance * divergence(N, S, calmat_dims, testLambda);
 
-        if (testMSE <= MSE) {
+        //TODO: Remove
+        printf("MSE[%d]: %f\n", idx, testMSE);
+        if (testMSE < MSE) {
             MSE    = testMSE;
-            lambda = S[idx];
+            lambda = testLambda;
         }
 
     }
@@ -94,6 +103,9 @@ extern void soft_weight_singular_vectors(long N, long kernel_dims[3], long calre
     for (int idx = 0; idx < N; idx++) {
         t = (S[idx] - lambda)/S[idx];
         S[idx] = ((!isnan(t) && t > 0)? t: 0);
+
+        //TODO: remove
+        printf("WE[%d]: %f\n", idx, S[idx]);
     }
 
 }

--- a/src/calib/softweight.c
+++ b/src/calib/softweight.c
@@ -8,6 +8,11 @@
  * Iyer S, Ong F, Lustig M.
  * Towards a Parameter­Free ESPIRiT: Soft­Weighting for Robust Coil Sensitivity Estimation
  * Submitted to ISMRM 2016.
+ * 
+ * Candès E, Long C, Trzasko J. 
+ * Unbiased Risk Estimates for Singular Value Thresholding and Spectral Estimators.
+ * IEEE Transactions on Signal Processing 61, no. 19 (2013): 4643­657.
+ *
  */
 
 #include <assert.h>
@@ -28,6 +33,16 @@
 
 #include "softweight.h"
 
+/*
+ * divergence - Calculates the divergence of the spectral estimator for use in SURE as
+ *              proposed by Candès et al.
+ *
+ * Parameters:
+ *  N            - Number of singular values.
+ *  S            - Array of singular values.
+ *  calmat_dims  - Dimension of the calibration matrix.
+ *  lambda       - Soft-threshold to test.
+ */
 static float divergence(long N, float S[N], long calmat_dims[2], float lambda) {
 
     int idx, jdx;
@@ -54,7 +69,7 @@ static float divergence(long N, float S[N], long calmat_dims[2], float lambda) {
 
 }
 
-extern void soft_weight_singular_vectors(long N, long kernel_dims[3], long calreg_dims[4], float S[N]) {
+extern void soft_weight_singular_vectors(long N, long kernel_dims[3], long calreg_dims[4], float S[N], float W[N]) {
 
     int idx = 0, jdx = 0;
 
@@ -94,13 +109,12 @@ extern void soft_weight_singular_vectors(long N, long kernel_dims[3], long calre
 
     }
 
-    //TODO : DEBUG
-    printf("Lambda: %f\n", lambda);
+    debug_printf(DP_DEBUG1, "Soft threshold (Lambda): %f\n", lambda);
 
     for (int idx = 0; idx < N; idx++) {
         t = (S[idx] - lambda)/S[idx];
         t = sqrtf(2 * t - t * t);
-        S[idx] = ((!isnan(t) && t > 0)? t: 0);
+        W[idx] = ((!isnan(t) && t > 0)? t: 0);
     }
 
 }

--- a/src/calib/softweight.c
+++ b/src/calib/softweight.c
@@ -4,6 +4,10 @@
  *
  * Authors: 
  * 2015 Siddharth Iyer <sid8795@gmail.com>
+ *
+ * Iyer S, Ong F, Lustig M.
+ * Towards a Parameter­Free ESPIRiT: Soft­Weighting for Robust Coil Sensitivity Estimation
+ * Submitted to ISMRM 2016.
  */
 
 #include <assert.h>

--- a/src/calib/softweight.c
+++ b/src/calib/softweight.c
@@ -64,8 +64,6 @@ extern void soft_weight_singular_vectors(long N, long kernel_dims[3], long calre
     float Y = calmat_dims[0] * calmat_dims[1] * variance;
     float G = 0;
     for (jdx = 0; jdx < N; jdx++) {
-        //TODO: Delete print
-        printf("S[%d]: %f\n", jdx, S[jdx]);
         G += S[jdx] * S[jdx];
     }
 
@@ -73,9 +71,6 @@ extern void soft_weight_singular_vectors(long N, long kernel_dims[3], long calre
     float testMSE = 0;
     float testLambda = 0;
     float MSE = -Y + G + variance * divergence(N, S, calmat_dims, lambda);
-
-    //TODO: REmove
-    printf("MSE[%d]: %f\n", idx, MSE);
 
     for (idx = 1; idx < N; idx++) {
 
@@ -88,8 +83,6 @@ extern void soft_weight_singular_vectors(long N, long kernel_dims[3], long calre
 
         testMSE = -Y + G + variance * divergence(N, S, calmat_dims, testLambda);
 
-        //TODO: Remove
-        printf("MSE[%d]: %f\n", idx, testMSE);
         if (testMSE < MSE) {
             MSE    = testMSE;
             lambda = testLambda;
@@ -102,10 +95,8 @@ extern void soft_weight_singular_vectors(long N, long kernel_dims[3], long calre
 
     for (int idx = 0; idx < N; idx++) {
         t = (S[idx] - lambda)/S[idx];
+        t = sqrtf(2 * t - t * t);
         S[idx] = ((!isnan(t) && t > 0)? t: 0);
-
-        //TODO: remove
-        printf("WE[%d]: %f\n", idx, S[idx]);
     }
 
 }

--- a/src/calib/softweight.h
+++ b/src/calib/softweight.h
@@ -1,0 +1,15 @@
+/* Copyright 2015. The Regents of the University of California.
+ * All rights reserved. Use of this source code is governed by 
+ * a BSD-style license which can be found in the LICENSE file.
+ *
+ * Authors: 
+ * 2015 Siddharth Iyer <sid8795@gmail.com>
+ */
+
+#ifndef _SOFT_WEIGHT_H_
+#define  _SOFT_WEIGHT_H_
+ 
+//TODO: Document
+extern void soft_weight_singular_vectors(long N, long kernel_dims[3], long calreg_dims[4], float S[N]);
+
+#endif

--- a/src/calib/softweight.h
+++ b/src/calib/softweight.h
@@ -4,6 +4,10 @@
  *
  * Authors: 
  * 2015 Siddharth Iyer <sid8795@gmail.com>
+ *
+ * Iyer S, Ong F, Lustig M.
+ * Towards a Parameter­Free ESPIRiT: Soft­Weighting for Robust Coil Sensitivity Estimation
+ * Submitted to ISMRM 2016.
  */
 
 #ifndef _SOFT_WEIGHT_H_

--- a/src/calib/softweight.h
+++ b/src/calib/softweight.h
@@ -6,14 +6,31 @@
  * 2015 Siddharth Iyer <sid8795@gmail.com>
  *
  * Iyer S, Ong F, Lustig M.
- * Towards a Parameter­Free ESPIRiT: Soft­Weighting for Robust Coil Sensitivity Estimation
+ * Towards a Parameter­Free ESPIRiT: Soft­Weighting for Robust Coil Sensitivity Estimation.
  * Submitted to ISMRM 2016.
+ *
+ * Candès E, Long C, Trzasko J. 
+ * Unbiased Risk Estimates for Singular Value Thresholding and Spectral Estimators.
+ * IEEE Transactions on Signal Processing 61, no. 19 (2013): 4643­657.
+ *
  */
 
 #ifndef _SOFT_WEIGHT_H_
 #define  _SOFT_WEIGHT_H_
  
-//TODO: Document
-extern void soft_weight_singular_vectors(long N, long kernel_dims[3], long calreg_dims[4], float S[N]);
+/**
+ * soft_weight_singular_vectors - This returns weights for the singular vectors derived from the 
+ *                                soft-thresholding operator proposed by Candès et al., as seen
+ *                                in "Towards a Parameter­Free ESPIRiT: Soft­Weighting for 
+ *                                Robust Coil Sensitivity Estimation."
+ * 
+ * Parameters:
+ *  N           - Number of singular values.
+ *  kernel_dims - Dimension of kernel.
+ *  calreg_dims - Calibration region dimensions.
+ *  S           - Array of singular values. 
+ *  W           - Array to store weights to.
+ */
+extern void soft_weight_singular_vectors(long N, long kernel_dims[3], long calreg_dims[4], float S[N], float W[N]);
 
 #endif

--- a/src/ecalib.c
+++ b/src/ecalib.c
@@ -5,6 +5,7 @@
  * Authors:
  * 2012-2013, Martin Uecker <uecker@eecs.berkeley.edu>
  * 2013 Dara Bahri <dbahri123@gmail.com>
+ * 2015 Siddharth Iyer <sid8795@gmail.com>
  */
 
 #define _GNU_SOURCE
@@ -34,7 +35,7 @@
 
 static void usage(const char* name, FILE* fd)
 {
-	fprintf(fd, 	"Usage: %s [-n num. s.values] [-t eigenv. threshold] [-c crop_value] [-k kernel_size] [-r cal_size] [-m maps]"
+	fprintf(fd, 	"Usage: %s [-n num. s.values] [-t eigenv. threshold] [-W soft-weight] [-c crop_value] [-k kernel_size] [-r cal_size] [-m maps]"
 			" <kspace> <sensitivites> [<ev-maps>]\n", name);
 }
 
@@ -49,6 +50,8 @@ static void help(void)
 		"-k ksize\tkernel size\n"
 		"-r cal_size\tLimits the size of the calibration region.\n"
 		"-m maps\t\tNumber of maps to compute.\n"
+                "-W weight\tThis soft-weights the singular vectors for better map estimates. Needs high second threshold"
+                    "(around 0.999).\n"
 		"-I\t\tintensity correction\n"
 		"-1\t\tperform only first part of the calibration\n");
 }
@@ -80,7 +83,10 @@ int main_ecalib(int argc, char* argv[])
 			break;
 
 		case 'W':
-			conf.weighting = true;
+			conf.numsv      = -1;
+			conf.threshold  = 0;
+			conf.orthiter   = false;
+			conf.weighting  = true;
 			break;
 
 		case 'S':

--- a/src/ecalib.c
+++ b/src/ecalib.c
@@ -50,7 +50,7 @@ static void help(void)
 		"-k ksize\tkernel size\n"
 		"-r cal_size\tLimits the size of the calibration region.\n"
 		"-m maps\t\tNumber of maps to compute.\n"
-                "-W weight\tThis soft-weights the singular vectors for better map estimates. Needs high second threshold"
+                "-W weight\tThis soft-weights the singular vectors for better map estimates. Needs high second threshold."
                     "(around 0.999).\n"
 		"-I\t\tintensity correction\n"
 		"-1\t\tperform only first part of the calibration\n");


### PR DESCRIPTION
I've modified the -W command to weight the singular vectors according to a soft-threshold derived from SURE. One caveat is that the second threshold needs to be around 0.999, but in a sense, it is more consistent with the "=1" constraint of ESPIRiT.