### PR TITLE
fix bug in nufft -d x:y:z argument handling

### DIFF
--- a/src/nufft.c
+++ b/src/nufft.c
@@ -3,8 +3,8 @@
  * All rights reserved. Use of this source code is governed by
  * a BSD-style license which can be found in the LICENSE file.
  *
- * Authors: 
- * 2014 Frank Ong <frankong@berkeley.edu> 
+ * Authors:
+ * 2014 Frank Ong <frankong@berkeley.edu>
  * 2014-2015 Martin Uecker <martin.uecker@med.uni-goettingen.de>
  */
 
@@ -58,6 +58,7 @@ int main_nufft(int argc, char* argv[])
 
 		{ 'a', false, opt_set, &adjoint, "\tadjoint" },
 		{ 'i', false, opt_set, &inverse, "\tinverse" },
+		{ 'd', true, opt_vec3, &coilim_dims, " dimension\t dimension" },
 		{ 'D', true, opt_vec3, &coilim_dims, " x:y:z \tdimensions" },
 		{ 't', false, opt_set, &conf.toeplitz, "\ttoeplitz" },
 		{ 'l', true, opt_float, &lambda, " lambda\tl2 regularization" },
@@ -121,7 +122,7 @@ int main_nufft(int argc, char* argv[])
 
 		// Read image data
 		const complex float* img = load_cfl(argv[2], DIMS, coilim_dims);
- 
+
 		// Initialize kspace data
 		long ksp_dims[DIMS];
 		md_select_dims(DIMS, PHS1_FLAG|PHS2_FLAG, ksp_dims, traj_dims);

--- a/src/nufft.c
+++ b/src/nufft.c
@@ -58,7 +58,7 @@ int main_nufft(int argc, char* argv[])
 
 		{ 'a', false, opt_set, &adjoint, "\tadjoint" },
 		{ 'i', false, opt_set, &inverse, "\tinverse" },
-		{ 'd', true, opt_vec3, &coilim_dims, " x:y:z \tdimensions" },
+		{ 'D', true, opt_vec3, &coilim_dims, " x:y:z \tdimensions" },
 		{ 't', false, opt_set, &conf.toeplitz, "\ttoeplitz" },
 		{ 'l', true, opt_float, &lambda, " lambda\tl2 regularization" },
 		{ 'm', true, opt_int, &cgconf.maxiter, NULL },
@@ -66,6 +66,11 @@ int main_nufft(int argc, char* argv[])
 
 	cmdline(&argc, argv, 3, 3, usage_str, help_str, ARRAY_SIZE(opts), opts);
 
+	for (int i = 0; i < ARRAY_SIZE(opts); i++) {
+		if (opts[i].c == 'D') {
+			sizeinit = true;
+		}
+	}
 
 	// Read trajectory
 	long traj_dims[DIMS];


### PR DESCRIPTION
Hi,

This PR fixes two bugs in `nufft` argument handling that were introduced by the changes in #20.

- The first is that the dimensions vec3 argument name needs to be changed to `-D` for all 3 values to be respected.
- also, `sizeinit` was never set to `true` when the dimensions were specified.  I manually check the argument strings to set this, but perhaps there is an easier way to verify if `-D` was passed in?

I came across this while trying to run the following line from the matlab `noncart.m` example:
https://github.com/mikgroup/espirit-matlab-examples/blob/97cacdd7e2cc8b62f90a3c8e052a5f6a2315795f/noncart.m#L27
```matlab
% reconstruct low-resolution image and transform back to k-space
lowres_img = bart('nufft -i -d24:24:1 -t', traj_rad2, ksp_sim);
```
After the proposed changes (and changing `-d` to `-D` in the example), the size of `lowres_img` is as expected.




