### PR TITLE
Matlab-like python tool.

### DIFF
--- a/python/bart.py
+++ b/python/bart.py
@@ -1,0 +1,66 @@
+# Copyright 2016. The Regents of the University of California.
+# All rights reserved. Use of this source code is governed by 
+# a BSD-style license which can be found in the LICENSE file.
+#
+# Authors: 
+# 2016 Siddharth Iyer <sid8795@gmail.com>
+
+import subprocess as sp
+import tempfile as tmp
+import cfl
+import os
+
+def bart(cmd='', nargout=0, *args):
+
+    if not cmd or not nargout:
+        print "Usage: bart <command> <arguments...>";
+        return None
+
+    bart_path = os.environ['TOOLBOX_PATH'] + '/bart ';
+
+    if not bart_path:
+        if os.path.isfile('/usr/local/bin/bart'):
+            bart_path = '/usr/local/bin'
+        elif os.path.isfile('/usr/bin/bart'):
+            bart_path = '/usr/bin'
+        else:
+            raise Exception('Environment variable TOOLBOX_PATH is not set.')
+
+    name = tmp.NamedTemporaryFile().name
+
+    nargin = len(args);
+    infiles = [name + 'in' + str(idx) for idx in range(nargin)]
+    in_str = ' '.join(infiles)
+
+    for idx in range(nargin):
+        cfl.writecfl(infiles[idx], args[idx])
+
+    outfiles = [name + 'out' + str(idx) for idx in range(nargout)]
+    out_str = ' '.join(outfiles)
+
+    #TODO: Windows option.
+    ERR = os.system(bart_path + '/bart ' + cmd + ' ' + in_str + ' ' + out_str);
+
+    for elm in infiles:
+        if os.path.isfile(elm + '.cfl'):
+            os.remove(elm + '.cfl')
+        if os.path.isfile(elm + '.hdr'):
+            os.remove(elm + '.hdr')
+
+    output = []
+    for idx in range(nargout):
+        elm = outfiles[idx]
+        if not ERR:
+            output.append(cfl.readcfl(elm))
+        if os.path.isfile(elm + '.cfl'):
+            os.remove(elm + '.cfl')
+        if os.path.isfile(elm + '.hdr'):
+            os.remove(elm + '.hdr')
+
+    if ERR:
+        raise Exception("Command exited with an error.")
+
+    if nargout == 1:
+        output = output[0]
+
+    return output


### PR DESCRIPTION
This is the python version of the matlab file bart.m. I've basically replicated the matlab code, with the exception of an import that needs to be done at startup. Example use case:

```
from bart import bart
from cfl import readcfl

X = readcfl('data')
emaps = bart('ecalib', 1, X)

A = bart('calmat -k 6 -r 24', 1, X)
U,S,V = bart('svd', 3, A)
```

I haven't done added a cygwin/ windows option, since I do not have a windows computer. I did not update the readme either, since I do not know the procedure of doing so. 

Let me know if you want me to look into creating a vars.py just like vars.m.