### PR TITLE
Rewrite of CFL Python interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,8 +91,13 @@ matrix:
       before_install:
         - brew update
         - brew install fftw gcc47 homebrew/science/openblas
+
+    - env: MACPORTS=0
+      os: osx
+      before_install:
+        - brew update
       script:
-          - make test
+          - brew install mrirecon/bart/bart
 
 script:
   - make bart

--- a/python/cfl.py
+++ b/python/cfl.py
@@ -38,7 +38,6 @@ def readcfl(
     # remove trailing singleton dimensions
     # by finding the last non-singleton dim
     shape = shape[:np.searchsorted(np.cumprod(shape), data_size) + 1]
-    
 
     # load data
     with open(filepath + ".cfl", "r") as data_file:

--- a/python/cfl.py
+++ b/python/cfl.py
@@ -1,10 +1,12 @@
 # Copyright 2013-2015. The Regents of the University of California.
+# Copyright 2016. Riccardo Metere.
 # All rights reserved. Use of this source code is governed by 
 # a BSD-style license which can be found in the LICENSE file.
 #
 # Authors: 
 # 2013 Martin Uecker <uecker@eecs.berkeley.edu>
 # 2015 Jonathan Tamir <jtamir@eecs.berkeley.edu>
+# 2016 Riccardo Metere <riccardo@metere.it>
 
 from __future__ import unicode_literals
 

--- a/python/cfl.py
+++ b/python/cfl.py
@@ -32,8 +32,13 @@ def readcfl(
         dim_line = header_file.readline()
 
     # obtain the shape of the image
-    shape = [int(i) for i in dim_line.split(' ') if int(i) > 1]
+    shape = [int(i) for i in dim_line.split(' ')]
+    # calculate the data size
     data_size = int(np.prod(shape))
+    # remove trailing singleton dimensions
+    # by finding the last non-singleton dim
+    shape = shape[:np.searchsorted(np.cumprod(shape), data_size) + 1]
+    
 
     # load data
     with open(filepath + ".cfl", "r") as data_file:

--- a/python/cfl.py
+++ b/python/cfl.py
@@ -6,6 +6,8 @@
 # 2013 Martin Uecker <uecker@eecs.berkeley.edu>
 # 2015 Jonathan Tamir <jtamir@eecs.berkeley.edu>
 
+from __future__ import unicode_literals
+
 import os  # Miscellaneous operating system interfaces
 import numpy as np  # NumPy (multidimensional numerical arrays library)
 
@@ -32,7 +34,7 @@ def readcfl(
         dim_line = header_file.readline()
 
     # obtain the shape of the image
-    shape = [int(i) for i in dim_line.split(' ')]
+    shape = [int(i) for i in dim_line.strip().split(' ')]
     # remove trailing singleton dimensions from shape
     while shape[-1] == 1:
         shape.pop(-1)
@@ -69,8 +71,8 @@ def writecfl(
 
     # save header
     with open(filepath + '.hdr', 'w') as header_file:
-        header_file.write(str('# Dimensions'))
-        header_file.write(str(' '.join([str(n) for n in array.shape])))
+        header_file.write(str('# Dimensions\n'))
+        header_file.write(str(' '.join([str(n) for n in array.shape])) + '\n')
 
     # save data
     with open(filepath + '.cfl', 'w') as data_file:

--- a/python/cfl.py
+++ b/python/cfl.py
@@ -11,6 +11,7 @@ from __future__ import unicode_literals
 import os  # Miscellaneous operating system interfaces
 import numpy as np  # NumPy (multidimensional numerical arrays library)
 
+
 # ======================================================================
 def readcfl(
         basename,

--- a/python/cfl.py
+++ b/python/cfl.py
@@ -33,11 +33,11 @@ def readcfl(
 
     # obtain the shape of the image
     shape = [int(i) for i in dim_line.split(' ')]
+    # remove trailing singleton dimensions from shape
+    while shape[-1] == 1:
+        shape.pop(-1)
     # calculate the data size
     data_size = int(np.prod(shape))
-    # remove trailing singleton dimensions
-    # by finding the last non-singleton dim
-    shape = shape[:np.searchsorted(np.cumprod(shape), data_size) + 1]
 
     # load data
     with open(filepath + ".cfl", "r") as data_file:

--- a/tests/pythoncfl.py
+++ b/tests/pythoncfl.py
@@ -10,8 +10,8 @@ def errprint(*args, **kwargs):
 
 def main(out_name, in_name):
 	input = cfl.readcfl(in_name)
-	#cfl.writecfl(input, out_name)
-	cfl.writecfl(out_name, input)
+	cfl.writecfl(input, out_name)
+	# cfl.writecfl(out_name, input)
 	return 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
function restyle and documentation

WARNING: writecfl signature NOT backward compatible (but can be easily made so, at the cost of less clean code)
