### PR TITLE
Use flags for estimate_pattern

### DIFF
--- a/rules/misc.mk
+++ b/rules/misc.mk
@@ -19,3 +19,4 @@ DOTHIS := $(shell $(root)/rules/update-version.sh)
 $(srcdir)/misc/version.o: $(srcdir)/misc/version.inc
 
 
+UTARGETS += test_pattern

--- a/src/bpsense.c
+++ b/src/bpsense.c
@@ -137,7 +137,7 @@ int main_bpsense(int argc, char* argv[])
 	} else {
 
 		pattern = md_alloc(N, dims1, CFL_SIZE);
-		estimate_pattern(N, ksp_dims, COIL_DIM, pattern, kspace_data);
+		estimate_pattern(N, ksp_dims, COIL_FLAG, pattern, kspace_data);
 	}
 
 	

--- a/src/calib/calmat.c
+++ b/src/calib/calmat.c
@@ -80,7 +80,7 @@ static complex float* pattern_matrix(long pcm_dims[2], const long kdims[3], cons
 	long pat_dims[4];
 	md_select_dims(4, ~MD_BIT(COIL_DIM), pat_dims, calreg_dims);
 	complex float* pattern = md_alloc_sameplace(4, pat_dims, CFL_SIZE, data);
-	estimate_pattern(4, calreg_dims, COIL_DIM, pattern, data);
+	estimate_pattern(4, calreg_dims, COIL_FLAG, pattern, data);
 
 	// compute calibration matrix of pattern
 	complex float* pm = calibration_matrix_mask(pcm_dims, kdims, mask, pat_dims, pattern);

--- a/src/grecon/grecon.c
+++ b/src/grecon/grecon.c
@@ -70,7 +70,7 @@ void grecon(struct grecon_conf* param,  const long dims1[DIMS], complex float* o
 
 		md_select_dims(DIMS, ~(COIL_FLAG | MAPS_FLAG), pat1_dims, dims1);
 		complex float* tpattern = md_alloc(DIMS, pat1_dims, CFL_SIZE);
-		estimate_pattern(DIMS, ksp1_dims, COIL_DIM, tpattern, kspace1);
+		estimate_pattern(DIMS, ksp1_dims, COIL_FLAG, tpattern, kspace1);
 		pattern = tpattern;
 
 	} else {

--- a/src/grecon/parslices.c
+++ b/src/grecon/parslices.c
@@ -95,8 +95,6 @@ void parslices2(grecon_fun_t grecon, void* param, const long dims[DIMS],
 
 	
 
-//	estimate_pattern(ksp1_dims, 3, pattern, kspace_data + (ksp_dims[0] / 2) * ksp_strs[0]);	// extract pattern form center of readout
-
 	bool ap_save = num_auto_parallelize;
 	num_auto_parallelize = false;
 

--- a/src/lrmatrix.c
+++ b/src/lrmatrix.c
@@ -154,7 +154,7 @@ int main_lrmatrix(int argc, char* argv[])
         if (!decom) {
 
                 pattern = md_alloc(DIMS, idims, CFL_SIZE);
-                estimate_pattern(DIMS, idims, TIME_DIM, pattern, idata);
+                estimate_pattern(DIMS, idims, TIME_FLAG, pattern, idata);
         }
 
 	// Initialize algorithm

--- a/src/misc/mri.c
+++ b/src/misc/mri.c
@@ -74,7 +74,7 @@ void transfer_function(void* _data, const complex float* pattern, complex float*
 
 
 
-void estimate_pattern_flags(unsigned int D, const long dims[D], unsigned int flags, complex float* pattern, const complex float* kspace_data)
+void estimate_pattern(unsigned int D, const long dims[D], unsigned int flags, complex float* pattern, const complex float* kspace_data)
 {
 	md_zrss(D, dims, flags, pattern, kspace_data);
 
@@ -88,12 +88,6 @@ void estimate_pattern_flags(unsigned int D, const long dims[D], unsigned int fla
 
 	md_zcmp2(D, dims2, strs2, pattern, strs2, pattern, strs1, &(complex float){ 0. });
 	md_zsub2(D, dims2, strs2, pattern, strs1, &(complex float){ 1. }, strs2, pattern);
-}
-
-void estimate_pattern(unsigned int D, const long dims[D], unsigned int dim, complex float* pattern, const complex float* kspace_data)
-{
-	assert(dim < D);
-	estimate_pattern_flags(D, dims, MD_BIT(dim), pattern, kspace_data);
 }
 
 
@@ -134,7 +128,7 @@ void calib_geom(long caldims[DIMS], long calpos[DIMS], const long calsize[3], co
 	md_select_dims(DIMS, ~COIL_FLAG, pat_dims, in_dims);
 	
 	complex float* pattern = md_alloc(DIMS, pat_dims, CFL_SIZE);
-	estimate_pattern(DIMS, in_dims, COIL_DIM, pattern, in_data);
+	estimate_pattern(DIMS, in_dims, COIL_FLAG, pattern, in_data);
 
 	for (unsigned int i = 0; i < DIMS; i++)
 		caldims[i] = 1;

--- a/src/misc/mri.c
+++ b/src/misc/mri.c
@@ -74,15 +74,13 @@ void transfer_function(void* _data, const complex float* pattern, complex float*
 
 
 
-
-void estimate_pattern(unsigned int D, const long dims[D], unsigned int dim, complex float* pattern, const complex float* kspace_data)
+void estimate_pattern_flags(unsigned int D, const long dims[D], unsigned int flags, complex float* pattern, const complex float* kspace_data)
 {
-	md_zrss(D, dims, MD_BIT(dim), pattern, kspace_data);
+	md_zrss(D, dims, flags, pattern, kspace_data);
 
 	long dims2[D];
 	long strs2[D];
-	assert(dim < D);
-	md_select_dims(D, ~MD_BIT(dim), dims2, dims);
+	md_select_dims(D, ~flags, dims2, dims);
 	md_calc_strides(D, strs2, dims2, CFL_SIZE);
 
 	long strs1[D];
@@ -92,6 +90,11 @@ void estimate_pattern(unsigned int D, const long dims[D], unsigned int dim, comp
 	md_zsub2(D, dims2, strs2, pattern, strs1, &(complex float){ 1. }, strs2, pattern);
 }
 
+void estimate_pattern(unsigned int D, const long dims[D], unsigned int dim, complex float* pattern, const complex float* kspace_data)
+{
+	assert(dim < D);
+	estimate_pattern_flags(D, dims, MD_BIT(dim), pattern, kspace_data);
+}
 
 
 static void calib_readout_pos(const long caldims[DIMS], long calpos[DIMS], const long in_dims[DIMS], const complex float* in_data)

--- a/src/misc/mri.h
+++ b/src/misc/mri.h
@@ -74,8 +74,7 @@ struct transfer_data_s {
 typedef void (*transfer_fun_t)(void* data, const _Complex float* pattern, _Complex float* dst, const _Complex float* src);
 
 extern void transfer_function(void* _data, const _Complex float* pattern, _Complex float* dst, const _Complex float* src);
-extern void estimate_pattern(unsigned int D, const long dims[__VLA(D)], unsigned int dim, _Complex float* pattern, const _Complex float* kspace_data);
-extern void estimate_pattern_flags(unsigned int D, const long dims[__VLA(D)], unsigned int flags, _Complex float* pattern, const _Complex float* kspace_data);
+extern void estimate_pattern(unsigned int D, const long dims[__VLA(D)], unsigned int flags, _Complex float* pattern, const _Complex float* kspace_data);
 extern _Complex float* extract_calib(long caldims[DIMS], const long calsize[3], const long in_dims[DIMS], const _Complex float* in_data, _Bool fixed);
 extern _Complex float* extract_calib2(long caldims[DIMS], const long calsize[3], const long in_dims[DIMS], const long in_strs[DIMS], const _Complex float* in_data, _Bool fixed);
 extern void data_consistency(const long dims[DIMS], _Complex float* dst, const _Complex float* pattern, const _Complex float* kspace1, const _Complex float* kspace2);

--- a/src/misc/mri.h
+++ b/src/misc/mri.h
@@ -75,6 +75,7 @@ typedef void (*transfer_fun_t)(void* data, const _Complex float* pattern, _Compl
 
 extern void transfer_function(void* _data, const _Complex float* pattern, _Complex float* dst, const _Complex float* src);
 extern void estimate_pattern(unsigned int D, const long dims[__VLA(D)], unsigned int dim, _Complex float* pattern, const _Complex float* kspace_data);
+extern void estimate_pattern_flags(unsigned int D, const long dims[__VLA(D)], unsigned int flags, _Complex float* pattern, const _Complex float* kspace_data);
 extern _Complex float* extract_calib(long caldims[DIMS], const long calsize[3], const long in_dims[DIMS], const _Complex float* in_data, _Bool fixed);
 extern _Complex float* extract_calib2(long caldims[DIMS], const long calsize[3], const long in_dims[DIMS], const long in_strs[DIMS], const _Complex float* in_data, _Bool fixed);
 extern void data_consistency(const long dims[DIMS], _Complex float* dst, const _Complex float* pattern, const _Complex float* kspace1, const _Complex float* kspace2);

--- a/src/nlinv.c
+++ b/src/nlinv.c
@@ -100,7 +100,7 @@ int main_nlinv(int argc, char* argv[])
 
 		md_copy_dims(DIMS, pat_dims, img_dims);
 		pattern = anon_cfl("", DIMS, pat_dims);
-		estimate_pattern(DIMS, ksp_dims, COIL_DIM, pattern, kspace_data);
+		estimate_pattern(DIMS, ksp_dims, COIL_FLAG, pattern, kspace_data);
 	}
 
 

--- a/src/pattern.c
+++ b/src/pattern.c
@@ -1,9 +1,10 @@
-/* Copyright 2013. The Regents of the University of California.
+/* Copyright 2013, 2016. The Regents of the University of California.
  * All rights reserved. Use of this source code is governed by 
  * a BSD-style license which can be found in the LICENSE file.
  *
  * Authors: 
  * 2012-2013 Martin Uecker <uecker@eecs.berkeley.edu>
+ * 2016 Jonathan Tamir <jtamir@eecs.berkeley.edu>
  */
 
 
@@ -17,6 +18,7 @@
 #include "misc/mmio.h"
 #include "misc/mri.h"
 #include "misc/misc.h"
+#include "misc/opts.h"
 
 
 
@@ -26,22 +28,27 @@ static const char help_str[] = "Compute sampling pattern from kspace\n";
 
 int main_pattern(int argc, char* argv[])
 {
-	mini_cmdline(argc, argv, 2, usage_str, help_str);
+
+	unsigned int flags = COIL_FLAG;
+
+	const struct opt_s opts[] = {
+
+		OPT_UINT('s', &flags, "bitmask", "Squash dimensions selected by bitmask"),
+	};
+
+	cmdline(&argc, argv, 2, 2, usage_str, help_str, ARRAY_SIZE(opts), opts);
 
 	unsigned int N = DIMS;
 	long in_dims[N];
 	long out_dims[N];
-	
-	unsigned int dim = COIL_DIM;
-	assert(dim < N);
 
 	complex float* kspace = load_cfl(argv[1], N, in_dims);
 
-	md_select_dims(N, ~MD_BIT(dim), out_dims, in_dims);
+	md_select_dims(N, ~flags, out_dims, in_dims);
 	
 	complex float* pattern = create_cfl(argv[2], N, out_dims);
 
-	estimate_pattern(N, in_dims, dim, pattern, kspace);
+	estimate_pattern_flags(N, in_dims, flags, pattern, kspace);
 
 	unmap_cfl(N, in_dims, kspace);
 	unmap_cfl(N, out_dims, pattern);

--- a/src/pattern.c
+++ b/src/pattern.c
@@ -48,7 +48,7 @@ int main_pattern(int argc, char* argv[])
 	
 	complex float* pattern = create_cfl(argv[2], N, out_dims);
 
-	estimate_pattern_flags(N, in_dims, flags, pattern, kspace);
+	estimate_pattern(N, in_dims, flags, pattern, kspace);
 
 	unmap_cfl(N, in_dims, kspace);
 	unmap_cfl(N, out_dims, pattern);

--- a/src/pics.c
+++ b/src/pics.c
@@ -237,7 +237,7 @@ int main_pics(int argc, char* argv[])
 
 		md_select_dims(DIMS, ~COIL_FLAG, pat_dims, ksp_dims);
 		pattern = md_alloc(DIMS, pat_dims, CFL_SIZE);
-		estimate_pattern(DIMS, ksp_dims, COIL_DIM, pattern, kspace);
+		estimate_pattern(DIMS, ksp_dims, COIL_FLAG, pattern, kspace);
 	}
 
 

--- a/src/pocsense.c
+++ b/src/pocsense.c
@@ -116,7 +116,7 @@ int main_pocsense(int argc, char* argv[])
 	float scaling = estimate_scaling(ksp_dims, NULL, kspace_data);
 	md_zsmul(N, ksp_dims, kspace_data, kspace_data, 1. / scaling);
 
-	estimate_pattern(N, ksp_dims, COIL_DIM, pattern, kspace_data);
+	estimate_pattern(N, ksp_dims, COIL_FLAG, pattern, kspace_data);
 
 
 	// -----------------------------------------------------------

--- a/src/sake/sake.c
+++ b/src/sake/sake.c
@@ -199,7 +199,7 @@ void lrmc(float alpha, int iter, float lambda, int N, const long dims[N], comple
 	complex float* pattern = md_alloc(N, dims1, CFL_SIZE);
 
 	//assert(5 == N);
-	estimate_pattern(N, dims, COIL_DIM, pattern, in);
+	estimate_pattern(N, dims, COIL_FLAG, pattern, in);
 
 	complex float* comp = md_alloc(N, dims1, CFL_SIZE);
 	md_zfill(N, dims1, comp, 1.);

--- a/src/sense/optcom.c
+++ b/src/sense/optcom.c
@@ -203,7 +203,7 @@ void replace_kspace(const long dims[DIMS], complex float* out, const complex flo
 
 	complex float* pattern = md_alloc(DIMS, dims_one, CFL_SIZE);
 
-	estimate_pattern(DIMS, dims_ksp, COIL_DIM, pattern, kspace);
+	estimate_pattern(DIMS, dims_ksp, COIL_FLAG, pattern, kspace);
 
 	data_consistency(dims_ksp, out, pattern, kspace, data);
 

--- a/src/sqpics.c
+++ b/src/sqpics.c
@@ -392,7 +392,7 @@ int main_sqpics(int argc, char* argv[])
 
 		md_select_dims(DIMS, ~COIL_FLAG, pat_dims, ksp_dims);
 		pattern = md_alloc(DIMS, pat_dims, CFL_SIZE);
-		estimate_pattern(DIMS, ksp_dims, COIL_DIM, pattern, kspace);
+		estimate_pattern(DIMS, ksp_dims, COIL_FLAG, pattern, kspace);
 	}
 
 

--- a/src/wave.c
+++ b/src/wave.c
@@ -136,7 +136,7 @@ int main_wave(int argc, char* argv[])
 	// initialize sampling pattern
 
 	complex float* pattern = md_alloc(DIMS, pat_dims, CFL_SIZE);
-	estimate_pattern(DIMS, ksp_dims, COIL_DIM, pattern, kspace);
+	estimate_pattern(DIMS, ksp_dims, COIL_FLAG, pattern, kspace);
 
 	// print some statistics
 

--- a/utests/test_pattern.c
+++ b/utests/test_pattern.c
@@ -1,0 +1,80 @@
+/* Copyright 2016. The Regents of the University of California.
+ * All rights reserved. Use of this source code is governed by
+ * a BSD-style license which can be found in the LICENSE file.
+ *
+ * Authors:
+ * 2016 Jonathan Tamir <jtamir@eecs.berkeley.edu>
+ */
+
+#include <stdlib.h>
+#include <complex.h>
+
+#include "num/flpmath.h"
+#include "num/multind.h"
+
+#include "misc/debug.h"
+#include "misc/misc.h"
+#include "misc/mri.h"
+
+#include "utest.h"
+
+
+static bool test_pattern_flags(unsigned int D, const long dims[D], unsigned int flags, const complex float* in, const complex float* ref)
+{
+	long odims[D];
+	md_select_dims(D, ~flags, odims, dims);
+
+	complex float* out = md_alloc(D, odims, CFL_SIZE);
+
+	estimate_pattern(D, dims, flags, out, in);
+
+	UT_ASSERT(md_znrmse(D, odims, ref, out) < UT_TOL);
+
+	md_free(out);
+
+	return true;
+}
+
+
+static bool test_pattern(void)
+{
+	const complex float in[1][5][3] = { {
+
+		{ 3., 0., 0. },
+		{ 0., 2., 0. },
+		{ .2, 0., 0. },
+		{ 0., 0., 0. },
+		{ 0., 2., 0. },
+	} };
+
+
+	const complex float ref0[1][5][3] = { {
+
+		{ 1., 0., 0. },
+		{ 0., 1., 0. },
+		{ 1., 0., 0. },
+		{ 0., 0., 0. },
+		{ 0., 1., 0. },
+	} };
+
+	const complex float ref2[1][1][3] = { {
+
+		{ 1., 1., 0. },
+	} };
+
+	const complex float ref3[1][1][1] = { {
+
+		{ 1. },
+	} };
+
+	long idims[3] = { 3, 5, 1 };
+
+
+	return (test_pattern_flags(3, idims, 0, &in[0][0][0], &ref0[0][0][0]) && 
+		test_pattern_flags(3, idims, 2, &in[0][0][0], &ref2[0][0][0]) &&
+		test_pattern_flags(3, idims, 3, &in[0][0][0], &ref3[0][0][0]));
+}
+
+
+UT_REGISTER_TEST(test_pattern);
+


### PR DESCRIPTION
The first two commits add a new `estimate_pattern_flags` function in order to maintain the same interface.

The third commit replaces `estimate_pattern` with the flags version and changes the original function's interface.