### PR TITLE
Use single precision in MATLAB/increase efficiency

### DIFF
--- a/matlab/readcfl.m
+++ b/matlab/readcfl.m
@@ -1,12 +1,12 @@
 function data = readcfl(filenameBase)
-% function data = readcfl(filenameBase)
+%READCFL Read complex data from file.
+%   Read in reconstruction data stored in filenameBase.cfl (complex float)
+%   based on dimensions stored in filenameBase.hdr.
 %
-% Read in recon data stored in filenameBase.cfl (complex float)
-% based on dimensions stored in filenameBase.hdr.
+%   Written to edit data with the Berkeley Advanced Reconstruction Toolbox (BART).
 %
 % Copyright 2016. CBClab, Maastricht University.
 % 2016 Tim Loderhose (t.loderhose@student.maastrichtuniversity.nl)
-
 
     dims = readReconHeader(filenameBase);
 

--- a/matlab/readcfl.m
+++ b/matlab/readcfl.m
@@ -3,16 +3,20 @@ function data = readcfl(filenameBase)
 %
 % Read in recon data stored in filenameBase.cfl (complex float)
 % based on dimensions stored in filenameBase.hdr.
+%
+% Copyright 2016. CBClab, Maastricht University.
+% 2016 Tim Loderhose (t.loderhose@student.maastrichtuniversity.nl)
+
 
     dims = readReconHeader(filenameBase);
 
     filename = strcat(filenameBase,'.cfl');
     fid = fopen(filename);
 
-    data_r_i = fread(fid, prod([2 dims]), 'float32');
+    data_r_i = fread(fid, prod([2 dims]), '*float32');
     data_r_i = reshape(data_r_i, [2 dims]);
-    data = zeros(dims);
-    data(:) = data_r_i(1:2:end) + 1i*data_r_i(2:2:end);
+    data = complex(zeros(dims,'single'),0);
+    data(:) = complex(data_r_i(1,:),data_r_i(2,:));
 
     fclose(fid);
 end

--- a/matlab/writecfl.m
+++ b/matlab/writecfl.m
@@ -1,9 +1,9 @@
 function writecfl(filenameBase,data)
-% writecfl(filenameBase, data)
-%    Writes recon data to filenameBase.cfl (complex float)
-%    and write the dimensions to filenameBase.hdr.
+%WRITECFL  Write complex data to file.
+%   Writes reconstruction data to filenameBase.cfl (complex float) and its
+%   dimensions to filenameBase.hdr.
 %
-%    Written to edit data for the Berkeley recon.
+%   Written to edit data with the Berkeley Advanced Reconstruction Toolbox (BART).
 %
 % Copyright 2013. Joseph Y Cheng.
 % Copyright 2016. CBClab, Maastricht University.

--- a/matlab/writecfl.m
+++ b/matlab/writecfl.m
@@ -6,7 +6,9 @@ function writecfl(filenameBase,data)
 %    Written to edit data for the Berkeley recon.
 %
 % Copyright 2013. Joseph Y Cheng.
+% Copyright 2016. CBClab, Maastricht University.
 % 2012 Joseph Y Cheng (jycheng@mrsrl.stanford.edu).
+% 2016 Tim Loderhose (t.loderhose@student.maastrichtuniversity.nl).
 
     dims = size(data);
     writeReconHeader(filenameBase,dims);
@@ -14,11 +16,9 @@ function writecfl(filenameBase,data)
     filename = strcat(filenameBase,'.cfl');
     fid = fopen(filename,'w');
     
-    data_o = zeros(prod(dims)*2,1);
-    data_o(1:2:end) = real(data(:));
-    data_o(2:2:end) = imag(data(:));
+    data = data(:);
     
-    fwrite(fid,data_o,'float32');
+    fwrite(fid,[real(data)'; imag(data)'],'float32');
     fclose(fid);
 end
 


### PR DESCRIPTION
As written in issue #46 , here are my slight changes to the BART MATLAB interface.
I tested it on a couple of datasets (3D scans - 16/24 channels) and some lower-dimensional mock-data to see that I read back what I wrote.