### PR TITLE
fix segfault in nufft_precond_create

### DIFF
--- a/src/noncart/nufft.c
+++ b/src/noncart/nufft.c
@@ -401,7 +401,7 @@ const struct operator_s* nufft_precond_create(const struct linop_s* nufft_op)
 	assert(data->conf.toeplitz);
 
 	unsigned int N = data->N;
-	unsigned int ND = pdata->N + 3;
+	unsigned int ND = N + 3;
 
 	pdata->N = N;
 	pdata->cim_dims = *TYPE_ALLOC(long[ND]);


### PR DESCRIPTION
`pdata->N` was used uninitialized in this function, leading to unpleasantness like segfaults.

The change was introduced in 145df11360299593d66888c58d072ea861d2f985 "CAST_UP/CAST_DOWN macros with run-time checking of down-casts", which changed

```
pdata->N = data->N;
unsigned int ND = pdata->N + 3;
```

to

```
unsigned int N = data->N;
unsigned int ND = pdata->N + 3;

pdata->N = N;
```
so `ND` is using `pdata->N` uninitialized.