### PR TITLE
fix subopt

### DIFF
--- a/src/misc/opts.c
+++ b/src/misc/opts.c
@@ -296,9 +296,10 @@ bool opt_select(void* ptr, char c, const char* optarg)
 
 bool opt_subopt(void* _ptr, char c, const char* optarg)
 {
+	UNUSED(c);
 	struct opt_subopt_s* ptr = _ptr;
 
-	process_option(c, optarg, "foo", "usage", "help", ptr->n, ptr->opts);
+	process_option(optarg[0], optarg + 1, "", "", "", ptr->n, ptr->opts);
 	return false;
 }
 

--- a/src/misc/opts.h
+++ b/src/misc/opts.h
@@ -47,6 +47,7 @@ typedef long opt_vec3_t[3];
 typedef float opt_fvec3_t[3];
 
 #define OPT_SEL(T, x, v)	&(struct opt_select_s){ (x), &(T){ (v) }, &(T){ *(x) }, sizeof(T) }
+#define OPT_SUB(n, opts)	&(struct opt_subopt_s){ (n), (opts) }
 
 #define OPT_SET(c, ptr, descr)			{ (c), false, opt_set, TYPE_CHECK(bool*, (ptr)), "\t" descr }
 #define OPT_CLEAR(c, ptr, descr)		{ (c), false, opt_clear, TYPE_CHECK(bool*, (ptr)), "\t" descr }
@@ -59,7 +60,7 @@ typedef float opt_fvec3_t[3];
 #define OPT_VEC3(c, ptr, argname, descr)	OPT_ARG(c, opt_vec3, opt_vec3_t, ptr, argname, descr)
 #define OPT_FLVEC3(c, ptr, argname, descr)	OPT_ARG(c, opt_float_vec3, opt_fvec3_t, ptr, argname, descr)
 #define OPT_SELECT(c, T, ptr, value, descr)	{ (c), false, opt_select, OPT_SEL(T, TYPE_CHECK(T*, ptr), value), "\t" descr }
-#define OPT_SUB(c, argname, descr, NR, opts)	OPT_ARG(c, opt_subopt, &(struct opt_subopt_s){ NR, opts }, argname, descr)
+#define OPT_SUBOPT(c, argname, descr, NR, opts)	OPT_ARG(c, opt_subopt, struct opt_subopt_s, OPT_SUB(NR, opts), argname, descr)
 
 extern void cmdline(int* argc, char* argv[], int min_args, int max_args, const char* usage_str, const char* help_str, int n, const struct opt_s opts[n]);
 


### PR DESCRIPTION
While working on a tool based on BART, I came across `OPT_SUBOPT()` and wanted to use it. Unfortunately, it seems like it was left behind in interface changes in the options code (e.g. changes to `OPT_ARG)` and did not work for me. 

With this commit,it works well for options without parameters, like `OPT_SELECT`. For options taking parameters (like `OPT_INT`), options and parameter need to be passed as a single argument, so e.g. quoted in the shell.

Still, this way is not really beautiful. Help for suboptions, for example, is not really pretty: 
- The options are listed with dashes, even though these are not needed 
- There is no overall help string for a suboption

Unfortunately, I don't have an idea on how to improve that.