### PR TITLE
png: add more png_write functions

### DIFF
--- a/src/misc/png.h
+++ b/src/misc/png.h
@@ -1,3 +1,6 @@
 
 extern int png_write_rgb24(const char* name, unsigned int w, unsigned int h, long inum, const unsigned char* buf);
+extern int png_write_rgb32(const char* name, unsigned int w, unsigned int h, long inum, const unsigned char* buf);
+extern int png_write_bgr24(const char* name, unsigned int w, unsigned int h, long inum, const unsigned char* buf);
+extern int png_write_bgr32(const char* name, unsigned int w, unsigned int h, long inum, const unsigned char* buf);
 


### PR DESCRIPTION
Since png_write was only used in bart toimg, it only supported the one
format used by toimg. For a new image export tool in view
(https://github.com/mrirecon/view), it is very useful to also use bart's
libpng interface. However, view uses the cairo graphics library, which
has a different convention on the byte order in RGB data. Therefore, we
need a BGR version of png_write. Since it also uses a 4-byte buffer per
pixel, we need a BGR32 (or BGRA) version¹.

This commits adds a generic function, which can deal with all of those
cases, as well as 4 wrappers. One of the wrappers corresponds to the
previous function.


¹: It actually uses a 4-byte buffer but not RGBA: the last byte is simply ignored. But since the current bart interface does not support strides, I approximate it using RGBA.