### PR TITLE
Parallel batch svd

### DIFF
--- a/src/lowrank/batchsvd.c
+++ b/src/lowrank/batchsvd.c
@@ -22,60 +22,64 @@
 
 void batch_svthresh(long M, long N, long num_blocks, float lambda, complex float dst[num_blocks][N][M])
 {
-	long minMN = MIN(M, N);
+#pragma omp parallel
+    {
+		long minMN = MIN(M, N);
+	
+		PTR_ALLOC(complex float[minMN][M], U);
+		PTR_ALLOC(complex float[N][minMN], VT);
+		PTR_ALLOC(float[minMN], S);
+		PTR_ALLOC(complex float[minMN][minMN], AA);
 
-	PTR_ALLOC(complex float[minMN][M], U);
-	PTR_ALLOC(complex float[N][minMN], VT);
-	PTR_ALLOC(float[minMN], S);
-	PTR_ALLOC(complex float[minMN][minMN], AA);
-
-	for (int b = 0; b < num_blocks; b++) {
-
-		// Compute upper bound | A^T A |_inf
-
-		// FIXME: this is based on gratuitous guess-work about the obscure
-		// API of this FORTRAN from ancient times... Is it really worth it?
-
-		blas_csyrk('U', (N <= M) ? 'T' : 'N', (N <= M) ? N : M, (N <= M) ? M : N, 1., M, dst[b], 0., minMN, *AA);
-
-		// lambda_max( A ) <= max_i sum_j | a_i^T a_j |
-
-		float s_upperbound = 0;
-
-		for (int i = 0; i < minMN; i++) {
-
-			float s = 0;
-
-			for (int j = 0; j < minMN; j++)
-				s += cabsf((*AA)[MAX(i, j)][MIN(i, j)]);
-
-			s_upperbound = MAX(s_upperbound, s);
+#pragma omp for
+		for (int b = 0; b < num_blocks; b++) {
+	
+			// Compute upper bound | A^T A |_inf
+	
+			// FIXME: this is based on gratuitous guess-work about the obscure
+			// API of this FORTRAN from ancient times... Is it really worth it?
+	
+			blas_csyrk('U', (N <= M) ? 'T' : 'N', (N <= M) ? N : M, (N <= M) ? M : N, 1., M, dst[b], 0., minMN, *AA);
+	
+			// lambda_max( A ) <= max_i sum_j | a_i^T a_j |
+	
+			float s_upperbound = 0;
+	
+			for (int i = 0; i < minMN; i++) {
+	
+				float s = 0;
+	
+				for (int j = 0; j < minMN; j++)
+					s += cabsf((*AA)[MAX(i, j)][MIN(i, j)]);
+	
+				s_upperbound = MAX(s_upperbound, s);
+			}
+	
+			/* avoid doing SVD-based thresholding if we know from
+			 * the upper bound that lambda_max <= lambda and the
+			 * result must be zero */
+	
+			if (s_upperbound < lambda * lambda) {
+	
+				mat_zero(N, M, dst[b]);
+				continue;
+			}
+	
+			lapack_svd_econ(M, N, *U, *VT, *S, dst[b]);
+	
+			// soft threshold
+			for (int i = 0; i < minMN; i++)
+				for (int j = 0; j < N; j++)
+					(*VT)[j][i] *= ((*S)[i] < lambda) ? 0. : ((*S)[i] - lambda);
+	
+	
+			blas_matrix_multiply(M, N, minMN, dst[b], *U, *VT);
 		}
-
-		/* avoid doing SVD-based thresholding if we know from
-		 * the upper bound that lambda_max <= lambda and the
-		 * result must be zero */
-
-		if (s_upperbound < lambda * lambda) {
-
-			mat_zero(N, M, dst[b]);
-			continue;
-		}
-
-		lapack_svd_econ(M, N, *U, *VT, *S, dst[b]);
-
-		// soft threshold
-		for (int i = 0; i < minMN; i++)
-			for (int j = 0; j < N; j++)
-				(*VT)[j][i] *= ((*S)[i] < lambda) ? 0. : ((*S)[i] - lambda);
-
-
-		blas_matrix_multiply(M, N, minMN, dst[b], *U, *VT);
-	}
-
-	PTR_FREE(U);
-	PTR_FREE(VT);
-	PTR_FREE(S);
-	PTR_FREE(AA);
+	
+		PTR_FREE(U);
+		PTR_FREE(VT);
+		PTR_FREE(S);
+		PTR_FREE(AA);
+    } // #pragma omp parallel
 }
 

--- a/src/lowrank/batchsvd.c
+++ b/src/lowrank/batchsvd.c
@@ -24,62 +24,62 @@ void batch_svthresh(long M, long N, long num_blocks, float lambda, complex float
 {
 #pragma omp parallel
     {
-		long minMN = MIN(M, N);
-	
-		PTR_ALLOC(complex float[minMN][M], U);
-		PTR_ALLOC(complex float[N][minMN], VT);
-		PTR_ALLOC(float[minMN], S);
-		PTR_ALLOC(complex float[minMN][minMN], AA);
+	long minMN = MIN(M, N);
+
+	PTR_ALLOC(complex float[minMN][M], U);
+	PTR_ALLOC(complex float[N][minMN], VT);
+	PTR_ALLOC(float[minMN], S);
+	PTR_ALLOC(complex float[minMN][minMN], AA);
 
 #pragma omp for
-		for (int b = 0; b < num_blocks; b++) {
-	
-			// Compute upper bound | A^T A |_inf
-	
-			// FIXME: this is based on gratuitous guess-work about the obscure
-			// API of this FORTRAN from ancient times... Is it really worth it?
-	
-			blas_csyrk('U', (N <= M) ? 'T' : 'N', (N <= M) ? N : M, (N <= M) ? M : N, 1., M, dst[b], 0., minMN, *AA);
-	
-			// lambda_max( A ) <= max_i sum_j | a_i^T a_j |
-	
-			float s_upperbound = 0;
-	
-			for (int i = 0; i < minMN; i++) {
-	
-				float s = 0;
-	
-				for (int j = 0; j < minMN; j++)
-					s += cabsf((*AA)[MAX(i, j)][MIN(i, j)]);
-	
-				s_upperbound = MAX(s_upperbound, s);
-			}
-	
-			/* avoid doing SVD-based thresholding if we know from
-			 * the upper bound that lambda_max <= lambda and the
-			 * result must be zero */
-	
-			if (s_upperbound < lambda * lambda) {
-	
-				mat_zero(N, M, dst[b]);
-				continue;
-			}
-	
-			lapack_svd_econ(M, N, *U, *VT, *S, dst[b]);
-	
-			// soft threshold
-			for (int i = 0; i < minMN; i++)
-				for (int j = 0; j < N; j++)
-					(*VT)[j][i] *= ((*S)[i] < lambda) ? 0. : ((*S)[i] - lambda);
-	
-	
-			blas_matrix_multiply(M, N, minMN, dst[b], *U, *VT);
+	for (int b = 0; b < num_blocks; b++) {
+
+		// Compute upper bound | A^T A |_inf
+
+		// FIXME: this is based on gratuitous guess-work about the obscure
+		// API of this FORTRAN from ancient times... Is it really worth it?
+
+		blas_csyrk('U', (N <= M) ? 'T' : 'N', (N <= M) ? N : M, (N <= M) ? M : N, 1., M, dst[b], 0., minMN, *AA);
+
+		// lambda_max( A ) <= max_i sum_j | a_i^T a_j |
+
+		float s_upperbound = 0;
+
+		for (int i = 0; i < minMN; i++) {
+
+			float s = 0;
+
+			for (int j = 0; j < minMN; j++)
+				s += cabsf((*AA)[MAX(i, j)][MIN(i, j)]);
+
+			s_upperbound = MAX(s_upperbound, s);
 		}
-	
-		PTR_FREE(U);
-		PTR_FREE(VT);
-		PTR_FREE(S);
-		PTR_FREE(AA);
+
+		/* avoid doing SVD-based thresholding if we know from
+		 * the upper bound that lambda_max <= lambda and the
+		 * result must be zero */
+
+		if (s_upperbound < lambda * lambda) {
+
+			mat_zero(N, M, dst[b]);
+			continue;
+		}
+
+		lapack_svd_econ(M, N, *U, *VT, *S, dst[b]);
+
+		// soft threshold
+		for (int i = 0; i < minMN; i++)
+			for (int j = 0; j < N; j++)
+				(*VT)[j][i] *= ((*S)[i] < lambda) ? 0. : ((*S)[i] - lambda);
+
+
+		blas_matrix_multiply(M, N, minMN, dst[b], *U, *VT);
+	}
+
+	PTR_FREE(U);
+	PTR_FREE(VT);
+	PTR_FREE(S);
+	PTR_FREE(AA);
     } // #pragma omp parallel
 }
 


### PR DESCRIPTION
Hello, I noticed that the batch SVD was not parallelized and was slowing down performance of BART running on increasing numbers of cores. This change improved our performance. Basically I'm just adding a openmp pragma around the num_blocks loop, which seems to be embarassingly parallel. The rest of the diff changes is related to the indenting. It passes the "make utest". I also ran make test but I'm not sure how to check that passed.