### PR TITLE
Flatten md parallel ndary

### DIFF
--- a/src/lowrank/batchsvd.c
+++ b/src/lowrank/batchsvd.c
@@ -22,60 +22,64 @@
 
 void batch_svthresh(long M, long N, long num_blocks, float lambda, complex float dst[num_blocks][N][M])
 {
-	long minMN = MIN(M, N);
+#pragma omp parallel
+    {
+		long minMN = MIN(M, N);
+	
+		PTR_ALLOC(complex float[minMN][M], U);
+		PTR_ALLOC(complex float[N][minMN], VT);
+		PTR_ALLOC(float[minMN], S);
+		PTR_ALLOC(complex float[minMN][minMN], AA);
 
-	PTR_ALLOC(complex float[minMN][M], U);
-	PTR_ALLOC(complex float[N][minMN], VT);
-	PTR_ALLOC(float[minMN], S);
-	PTR_ALLOC(complex float[minMN][minMN], AA);
-
-	for (int b = 0; b < num_blocks; b++) {
-
-		// Compute upper bound | A^T A |_inf
-
-		// FIXME: this is based on gratuitous guess-work about the obscure
-		// API of this FORTRAN from ancient times... Is it really worth it?
-
-		blas_csyrk('U', (N <= M) ? 'T' : 'N', (N <= M) ? N : M, (N <= M) ? M : N, 1., M, dst[b], 0., minMN, *AA);
-
-		// lambda_max( A ) <= max_i sum_j | a_i^T a_j |
-
-		float s_upperbound = 0;
-
-		for (int i = 0; i < minMN; i++) {
-
-			float s = 0;
-
-			for (int j = 0; j < minMN; j++)
-				s += cabsf((*AA)[MAX(i, j)][MIN(i, j)]);
-
-			s_upperbound = MAX(s_upperbound, s);
+#pragma omp for
+		for (int b = 0; b < num_blocks; b++) {
+	
+			// Compute upper bound | A^T A |_inf
+	
+			// FIXME: this is based on gratuitous guess-work about the obscure
+			// API of this FORTRAN from ancient times... Is it really worth it?
+	
+			blas_csyrk('U', (N <= M) ? 'T' : 'N', (N <= M) ? N : M, (N <= M) ? M : N, 1., M, dst[b], 0., minMN, *AA);
+	
+			// lambda_max( A ) <= max_i sum_j | a_i^T a_j |
+	
+			float s_upperbound = 0;
+	
+			for (int i = 0; i < minMN; i++) {
+	
+				float s = 0;
+	
+				for (int j = 0; j < minMN; j++)
+					s += cabsf((*AA)[MAX(i, j)][MIN(i, j)]);
+	
+				s_upperbound = MAX(s_upperbound, s);
+			}
+	
+			/* avoid doing SVD-based thresholding if we know from
+			 * the upper bound that lambda_max <= lambda and the
+			 * result must be zero */
+	
+			if (s_upperbound < lambda * lambda) {
+	
+				mat_zero(N, M, dst[b]);
+				continue;
+			}
+	
+			lapack_svd_econ(M, N, *U, *VT, *S, dst[b]);
+	
+			// soft threshold
+			for (int i = 0; i < minMN; i++)
+				for (int j = 0; j < N; j++)
+					(*VT)[j][i] *= ((*S)[i] < lambda) ? 0. : ((*S)[i] - lambda);
+	
+	
+			blas_matrix_multiply(M, N, minMN, dst[b], *U, *VT);
 		}
-
-		/* avoid doing SVD-based thresholding if we know from
-		 * the upper bound that lambda_max <= lambda and the
-		 * result must be zero */
-
-		if (s_upperbound < lambda * lambda) {
-
-			mat_zero(N, M, dst[b]);
-			continue;
-		}
-
-		lapack_svd_econ(M, N, *U, *VT, *S, dst[b]);
-
-		// soft threshold
-		for (int i = 0; i < minMN; i++)
-			for (int j = 0; j < N; j++)
-				(*VT)[j][i] *= ((*S)[i] < lambda) ? 0. : ((*S)[i] - lambda);
-
-
-		blas_matrix_multiply(M, N, minMN, dst[b], *U, *VT);
-	}
-
-	PTR_FREE(U);
-	PTR_FREE(VT);
-	PTR_FREE(S);
-	PTR_FREE(AA);
+	
+		PTR_FREE(U);
+		PTR_FREE(VT);
+		PTR_FREE(S);
+		PTR_FREE(AA);
+    } // #pragma omp parallel
 }
 

--- a/src/num/multind.c
+++ b/src/num/multind.c
@@ -129,7 +129,7 @@ void md_parallel_nary(unsigned int C, unsigned int D, const long dim[D], unsigne
 		// Update ptr
 		void* moving_ptr[C];
 		for (unsigned int j = 0; j < C; j++)
-		moving_ptr[j] = ptr[j];
+			moving_ptr[j] = ptr[j];
 
 		for(int p = 0 ; p < nparallel ; p++)
 			for (unsigned int j = 0; j < C; j++)

--- a/src/num/multind.c
+++ b/src/num/multind.c
@@ -128,12 +128,13 @@ void md_parallel_nary(unsigned int C, unsigned int D, const long dim[D], unsigne
 
 		// Update ptr
 		void* moving_ptr[C];
-		for (unsigned int j = 0; j < C; j++)
-			moving_ptr[j] = ptr[j];
 
-		for(int p = 0 ; p < nparallel ; p++)
-			for (unsigned int j = 0; j < C; j++)
+		for (unsigned int j = 0; j < C; j++) 
+		{
+			moving_ptr[j] = ptr[j];
+			for(int p = 0 ; p < nparallel ; p++)
 				moving_ptr[j] += iter_i[p] * str[j][parallel_b[p]];
+		}
 
 		md_parallel_nary(C, D, dimc, flags, str, moving_ptr, data, fun);
 	}

--- a/src/num/multind.c
+++ b/src/num/multind.c
@@ -103,6 +103,16 @@ void md_parallel_nary(unsigned int C, unsigned int D, const long dim[D], unsigne
 		nparallel++;
 	}
 
+	// Select dims
+	long dimc[D];
+	long dimc_tmp[D];
+	md_copy_dims(D, dimc, dim);
+	for(int p = 0 ; p < nparallel ; p++)
+	{
+		md_select_dims(D, ~MD_BIT(parallel_b[p]), dimc_tmp, dimc);
+		md_copy_dims(D, dimc, dimc_tmp);
+	}
+
 	// Run parallel work
 	#pragma omp parallel for
 	for(long i = 0 ; i < total_iterations ; i++)
@@ -114,16 +124,6 @@ void md_parallel_nary(unsigned int C, unsigned int D, const long dim[D], unsigne
 		{
 			iter_i[p] = ii % parallel_dim[p];
 			ii /= parallel_dim[p];
-		}
-
-		// Select dims
-		long dimc[D];
-		long dimc_tmp[D];
-		md_copy_dims(D, dimc, dim);
-		for(int p = 0 ; p < nparallel ; p++)
-		{
-			md_select_dims(D, ~MD_BIT(parallel_b[p]), dimc_tmp, dimc);
-			md_copy_dims(D, dimc, dimc_tmp);
 		}
 
 		// Update ptr

--- a/src/num/multind.c
+++ b/src/num/multind.c
@@ -85,6 +85,9 @@ void md_parallel_nary(unsigned int C, unsigned int D, const long dim[D], unsigne
 		return;
 	}
 
+	long dimc[D];
+	md_select_dims(D, ~flags, dimc, dim);
+
 	// Collect all parallel dimensions
 	int parallel_dim[D];
 	int parallel_b[D];
@@ -101,16 +104,6 @@ void md_parallel_nary(unsigned int C, unsigned int D, const long dim[D], unsigne
 		if(total_iterations > 0) total_iterations *= parallel_dim[nparallel];
 		else total_iterations = parallel_dim[nparallel];
 		nparallel++;
-	}
-
-	// Select dims
-	long dimc[D];
-	long dimc_tmp[D];
-	md_copy_dims(D, dimc, dim);
-	for(int p = 0 ; p < nparallel ; p++)
-	{
-		md_select_dims(D, ~MD_BIT(parallel_b[p]), dimc_tmp, dimc);
-		md_copy_dims(D, dimc, dimc_tmp);
 	}
 
 	// Run parallel work
@@ -136,7 +129,7 @@ void md_parallel_nary(unsigned int C, unsigned int D, const long dim[D], unsigne
 				moving_ptr[j] += iter_i[p] * str[j][parallel_b[p]];
 		}
 
-		md_parallel_nary(C, D, dimc, flags, str, moving_ptr, data, fun);
+		md_nary(C, D, dimc, str, moving_ptr, data, fun);
 	}
 }
 

--- a/src/num/multind.c
+++ b/src/num/multind.c
@@ -89,7 +89,7 @@ void md_parallel_nary(unsigned int C, unsigned int D, const long dim[D], unsigne
 	md_select_dims(D, ~flags, dimc, dim);
 
 	// Collect all parallel dimensions
-	int parallel_dim[D];
+	long parallel_dim[D];
 	int parallel_b[D];
 	int nparallel = 0;
 	long total_iterations = 0L;

--- a/src/num/multind.c
+++ b/src/num/multind.c
@@ -85,28 +85,58 @@ void md_parallel_nary(unsigned int C, unsigned int D, const long dim[D], unsigne
 		return;
 	}
 
-	int b = ffsl(flags & -flags) - 1;
-	assert(MD_IS_SET(flags, b));
+    // Collect all parallel dimensions
+    int parallel_dim[D];
+    int parallel_b[D];
+    int nparallel = 0;
+    long total_iterations = 0L;
+    while(0 != flags)
+    {
+	    int b = ffsl(flags & -flags) - 1;
+	    assert(MD_IS_SET(flags, b));
+	    flags = MD_CLEAR(flags, b);
+	    debug_printf(DP_DEBUG4, "Parallelize: %d\n", dim[b]);
+        parallel_b[nparallel] = b;
+        parallel_dim[nparallel] = dim[b];
+        if(total_iterations > 0) total_iterations *= parallel_dim[nparallel];
+        else total_iterations = parallel_dim[nparallel];
+        nparallel++;
+    }
 
-	flags = MD_CLEAR(flags, b);
+    // Run parallel work
+    #pragma omp parallel for
+    for(long i = 0 ; i < total_iterations ; i++)
+    {
+      // Recover place in parallel iteration space
+      long iter_i[D];
+      long ii = i;
+      for(int p = nparallel-1 ; p >= 0 ; p--)
+      {
+        iter_i[p] = ii % parallel_dim[p];
+        ii /= parallel_dim[p];
+      }
 
-	long dimc[D];
-	md_select_dims(D, ~MD_BIT(b), dimc, dim);
+      // Select dims
+	  long dimc[D];
+	  long dimc_tmp[D];
+	  md_copy_dims(D, dimc, dim);
+      for(int p = 0 ; p < nparallel ; p++)
+      {
+	    md_select_dims(D, ~MD_BIT(parallel_b[p]), dimc_tmp, dimc);
+	    md_copy_dims(D, dimc, dimc_tmp);
+      }
 
-	debug_printf(DP_DEBUG4, "Parallelize: %d\n", dim[b]);
+      // Update ptr
+	  void* moving_ptr[C];
+      for (unsigned int j = 0; j < C; j++)
+	    moving_ptr[j] = ptr[j];
 
-	// FIXME: this probably doesn't nest
-	// (maybe collect all parallelizable dims into one giant loop?)
-	#pragma omp parallel for
-	for (long i = 0; i < dim[b]; i++) {
+      for(int p = 0 ; p < nparallel ; p++)
+        for (unsigned int j = 0; j < C; j++)
+	      moving_ptr[j] += iter_i[p] * str[j][parallel_b[p]];
 
-		void* moving_ptr[C];
-
-		for (unsigned int j = 0; j < C; j++)
-			moving_ptr[j] = ptr[j] + i * str[j][b];
-
-		md_parallel_nary(C, D, dimc, flags, str, moving_ptr, data, fun);
-	}
+      md_parallel_nary(C, D, dimc, flags, str, moving_ptr, data, fun);
+    }
 }
 
 


### PR DESCRIPTION
Hello,

I noticed the "FIXME" in the code. I think you're right, the parallel omp for probably does not operate in the nested way. I think it will probably only parallelize the first loop. 

In this code I just scan over the parallel dimensions and create a wide iteration space to run in the parallel loop. Then recover the original indices in the iter_i array using modulo arithmetic and use these to update the moving_ptr. 

This improves performance for our particular problem by about 13% overall on 22 cores. The only testing I did was to run "make utest". 