### PR TITLE
gpu fix

### DIFF
--- a/src/noir/model.c
+++ b/src/noir/model.c
@@ -157,7 +157,7 @@ struct noir_data* noir_init(const long dims[DIMS], const complex float* mask, co
 
 	data->pattern = ptr;
 
-	complex float* adj_pattern = md_alloc(DIMS, data->ptrn_dims, CFL_SIZE);
+	complex float* adj_pattern = my_alloc(DIMS, data->ptrn_dims, CFL_SIZE);
 
 	if (!conf->noncart) {
 


### PR DESCRIPTION
If gpu is used, adj_pattern should also be allocated on the GPU. Otherwise "ptr" and "adj_pattern" are allocated on different devices.