### PR TITLE
Primal Dual Algorithm

### DIFF
--- a/src/grecon/optreg.c
+++ b/src/grecon/optreg.c
@@ -238,7 +238,6 @@ void opt_bpursuit_configure(struct opt_reg_s* ropts, const struct operator_p_s* 
 	trafos[nr_penalties] = linop_clone(model_op);
 
 	ropts->r++;
-	ropts->algo = ADMM;
 }
 
 void opt_reg_configure(unsigned int N, const long img_dims[N], struct opt_reg_s* ropts, const struct operator_p_s* prox_ops[NUM_REGS], const struct linop_s* trafos[NUM_REGS], unsigned int llr_blk, bool randshift, bool use_gpu)

--- a/src/grecon/optreg.h
+++ b/src/grecon/optreg.h
@@ -14,7 +14,7 @@
 struct operator_p_s;
 struct linop_s;
 
-enum algo_t { CG, IST, FISTA, ADMM, NIHT };
+enum algo_t { CG, IST, FISTA, ADMM, NIHT, PRIDU };
 
 struct reg_s {
 

--- a/src/iter/italgos.h
+++ b/src/iter/italgos.h
@@ -1,4 +1,4 @@
-/* Copyright 2013-2014. The Regents of the University of California.
+/* Copyright 2013-2017. The Regents of the University of California.
  * Copyright 2016-2017. Martin Uecker.
  * All rights reserved. Use of this source code is governed by
  * a BSD-style license which can be found in the LICENSE file.
@@ -112,6 +112,15 @@ double power(unsigned int maxiter,
 	struct iter_op_s op,
 	float* u);
 	   
+void chambolle_pock(unsigned int maxiter, float epsilon, float tau, float sigma, float theta, float decay,
+	long N, long M,
+	const struct vec_iter_s* vops,
+	struct iter_op_s op_forw,
+	struct iter_op_s op_adj,
+	struct iter_op_p_s thresh1,
+	struct iter_op_p_s thresh2,
+	float* x,
+	struct iter_monitor_s* monitor);
 
 #include "misc/cppwrap.h"
 

--- a/src/iter/iter.c
+++ b/src/iter/iter.c
@@ -1,11 +1,11 @@
-/* Copyright 2013-2014. The Regents of the University of California.
+/* Copyright 2013-2017. The Regents of the University of California.
  * Copyright 2017. University of Oxford.
  * All rights reserved. Use of this source code is governed by 
  * a BSD-style license which can be found in the LICENSE file.
  *
  * Authors: 
  * 2012, 2014 Martin Uecker <uecker@eecs.berkeley.edu>
- * 2014	Jonathan Tamir <jtamir@eecs.berkeley.edu>
+ * 2014, 2017	Jon Tamir <jtamir@eecs.berkeley.edu>
  * 2014 Frank Ong <frankong@berkeley.edu>
  * 2017 Sofia Dimoudi <sofia.dimoudi@cardiov.ox.ac.uk>
  */
@@ -39,6 +39,7 @@ DEF_TYPEID(iter_conjgrad_conf);
 DEF_TYPEID(iter_landweber_conf);
 DEF_TYPEID(iter_ist_conf);
 DEF_TYPEID(iter_fista_conf);
+DEF_TYPEID(iter_chambolle_pock_conf);
 DEF_TYPEID(iter_pocs_conf);
 DEF_TYPEID(iter_admm_conf);
 DEF_TYPEID(iter_niht_conf);
@@ -125,6 +126,19 @@ const struct iter_niht_conf iter_niht_defaults = {
 	.maxiter = 50,
 	.tol = 1e-8,
 	.do_warmstart = false,
+};
+
+const struct iter_chambolle_pock_conf iter_chambolle_pock_defaults = {
+
+	.INTERFACE.TYPEID = &TYPEID(iter_chambolle_pock_conf),
+
+	.maxiter = 50,
+	.tol = 1e-8,
+	.theta = 1.,
+	.tau = 1.,
+	.sigma = 1.,
+	.decay = 1.,
+	.fast = false,
 };
 
 typedef void (*thresh_fun_t)(void* data, float lambda, float* dst, const float* src);

--- a/src/iter/iter.h
+++ b/src/iter/iter.h
@@ -1,4 +1,4 @@
-/* Copyright 2013-2014. The Regents of the University of California.
+/* Copyright 2013-2017. The Regents of the University of California.
  * Copyright 2016. Martin Uecker.
  * All rights reserved. Use of this source code is governed by
  * a BSD-style license which can be found in the LICENSE file.
@@ -79,6 +79,20 @@ struct iter_fista_conf {
 extern DEF_TYPEID(iter_fista_conf);
 
 
+struct iter_chambolle_pock_conf {
+
+	INTERFACE(iter_conf);
+
+	unsigned int maxiter;
+	float tau;
+	float sigma;
+	float theta;
+	float decay;
+	float tol;
+	bool fast;
+};
+
+extern DEF_TYPEID(iter_chambolle_pock_conf);
 
 struct iter_admm_conf {
 
@@ -135,6 +149,7 @@ extern const struct iter_fista_conf iter_fista_defaults;
 extern const struct iter_admm_conf iter_admm_defaults;
 extern const struct iter_pocs_conf iter_pocs_defaults;
 extern const struct iter_niht_conf iter_niht_defaults;
+extern const struct iter_chambolle_pock_conf iter_chambolle_pock_defaults;
 
 
 italgo_fun_f iter_conjgrad;

--- a/src/iter/iter2.h
+++ b/src/iter/iter2.h
@@ -1,4 +1,4 @@
-/* Copyright 2013-2016. The Regents of the University of California.
+/* Copyright 2013-2017. The Regents of the University of California.
  * Copyright 2016-2017. Martin Uecker.
  * All rights reserved. Use of this source code is governed by
  * a BSD-style license which can be found in the LICENSE file.
@@ -66,6 +66,7 @@ typedef italgo_fun2_f* italgo_fun2_t;
 italgo_fun2_f iter2_conjgrad;
 italgo_fun2_f iter2_ist;
 italgo_fun2_f iter2_fista;
+italgo_fun2_f iter2_chambolle_pock;
 italgo_fun2_f iter2_admm;
 italgo_fun2_f iter2_pocs;
 italgo_fun2_f iter2_niht;

--- a/src/iter/vec.h
+++ b/src/iter/vec.h
@@ -19,6 +19,7 @@ struct vec_iter_s {
 	void (*smul)(long N, float alpha, float* a, const float* x);
 	void (*xpay)(long N, float alpha, float* a, const float* x);
 	void (*axpy)(long N, float* a, float alpha, const float* x);
+	void (*axpbz)(long N, float* out, const float a, const float* x, const float b, const float* z);
 	void (*nzsupport)(long N, float* out, const float* in);
 };
 

--- a/src/num/gpukrnls.cu
+++ b/src/num/gpukrnls.cu
@@ -1,10 +1,10 @@
-/* Copyright 2013-2015. The Regents of the University of California.
+/* Copyright 2013-2017. The Regents of the University of California.
  * All rights reserved. Use of this source code is governed by 
  * a BSD-style license which can be found in the LICENSE file.
  *
  * Authors:
  * 2012-03-24 Martin Uecker <uecker@eecs.berkeley.edu>
- * 2015 Jonathan Tamir <jtamir@eecs.berkeley.edu>
+ * 2015,2017 Jon Tamir <jtamir@eecs.berkeley.edu>
  *
  * 
  * This file defines basic operations on vectors of floats/complex floats
@@ -110,6 +110,22 @@ __global__ void kern_xpay(int N, float beta, float* dst, const float* src)
 extern "C" void cuda_xpay(long N, float beta, float* dst, const float* src)
 {
 	kern_xpay<<<gridsize(N), blocksize(N)>>>(N, beta, dst, src);
+}
+
+
+__global__ void kern_axpbz(int N, float* dst, const float a1, const float* src1, const float a2, const float* src2)
+{
+	int start = threadIdx.x + blockDim.x * blockIdx.x;
+	int stride = blockDim.x * gridDim.x;
+
+	for (int i = start; i < N; i += stride)
+		dst[i] = a1 * src1[i] + a2 * src2[i];
+}
+
+
+extern "C" void cuda_axpbz(long N, float* dst, const float a1, const float* src1, const float a2, const float* src2)
+{
+	kern_axpbz<<<gridsize(N), blocksize(N)>>>(N, dst, a1, src1, a2, src2);
 }
 
 

--- a/src/num/gpukrnls.h
+++ b/src/num/gpukrnls.h
@@ -1,4 +1,4 @@
-/* Copyright 2013. The Regents of the University of California.
+/* Copyright 2013-2017. The Regents of the University of California.
  * All rights reserved. Use of this source code is governed by 
  * a BSD-style license which can be found in the LICENSE file.
  */
@@ -11,6 +11,7 @@ extern void cuda_float2double(long size, double* dst, const float* src);
 extern void cuda_double2float(long size, float* dst, const double* src);
 extern void cuda_sxpay(long size, float* y, float alpha, const float* src);
 extern void cuda_xpay(long N, float beta, float* dst, const float* src);
+extern void cuda_axpbz(long N, float* dst, const float a, const float* x, const float b, const float* z);
 extern void cuda_smul(long N, float alpha, float* dst, const float* src);
 extern void cuda_mul(long N, float* dst, const float* src1, const float* src2);
 extern void cuda_div(long N, float* dst, const float* src1, const float* src2);

--- a/src/num/gpuops.c
+++ b/src/num/gpuops.c
@@ -1,4 +1,4 @@
-/* Copyright 2013-2015. The Regents of the University of California.
+/* Copyright 2013-2017. The Regents of the University of California.
  * Copyright 2014. Joseph Y Cheng.
  * Copyright 2016. Martin Uecker.
  * All rights reserved. Use of this source code is governed by
@@ -7,7 +7,7 @@
  * Authors: 
  * 2012-2016	Martin Uecker <martin.uecker@med.uni-goettingen.de>
  * 2014 	Joseph Y Cheng <jycheng@stanford.edu>
- * 2015		Jonathan Tamir <jtamir@eecs.berkeley.edu>
+ * 2015,2017		Jon Tamir <jtamir@eecs.berkeley.edu>
  *
  * 
  * CUDA support functions. The file exports gpu_ops of type struct vec_ops
@@ -383,6 +383,7 @@ struct vec_iter_s {
 	void (*smul)(long N, float alpha, float* a, const float* x);
 	void (*xpay)(long N, float alpha, float* a, const float* x);
 	void (*axpy)(long N, float* a, float alpha, const float* x);
+	void (*axpbz)(long N, float* out, const float a, const float* x, const float b, const float* z);
 };
 
 extern const struct vec_iter_s gpu_iter_ops;
@@ -396,6 +397,7 @@ const struct vec_iter_s gpu_iter_ops = {
 	.norm = cuda_norm,
 	.axpy = cuda_saxpy,
 	.xpay = cuda_xpay,
+	.axpbz = cuda_axpbz,
 	.smul = cuda_smul,
 	.add = cuda_add,
 	.sub = cuda_sub,

--- a/src/num/vecops.h
+++ b/src/num/vecops.h
@@ -1,4 +1,4 @@
-/* Copyright 2013-2014. The Regents of the University of California.
+/* Copyright 2013-2017. The Regents of the University of California.
  * Copyright 2016. Martin Uecker.
  * Copyright 2017. University of Oxford.
  * All rights reserved. Use of this source code is governed by
@@ -19,6 +19,7 @@ struct vec_ops {
 	double (*zl1norm)(long N, const _Complex float* vec);
 
 	void (*axpy)(long N, float* a, float alpha, const float* x);
+	void (*axpbz)(long N, float* out, const float a, const float* x, const float b, const float* z);
 
 	void (*pow)(long N, float* dst, const float* src1, const float* src2);
 	void (*sqrt)(long N, float* dst, const float* src);

--- a/src/pics.c
+++ b/src/pics.c
@@ -127,6 +127,8 @@ int main_pics(int argc, char* argv[])
 	float admm_rho = iter_admm_defaults.rho;
 	unsigned int admm_maxitercg = iter_admm_defaults.maxitercg;
 
+	unsigned int gpun = 0;
+
 	struct opt_reg_s ropts;
 	opt_reg_init(&ropts);
 
@@ -143,6 +145,7 @@ int main_pics(int argc, char* argv[])
 		OPT_STRING('t', &traj_file, "file", "k-space trajectory"),
 		OPT_CLEAR('n', &randshift, "disable random wavelet cycle spinning"),
 		OPT_SET('g', &conf.gpu, "use GPU"),
+		OPT_UINT('G', &gpun, "gpun", "use GPU device gpun"),
 		OPT_STRING('p', &pat_file, "file", "pattern or weights"),
 		OPT_SELECT('I', enum algo_t, &ropts.algo, IST, "select IST"),
 		OPT_UINT('b', &llr_blk, "blk", "Lowrank block size"),
@@ -226,7 +229,10 @@ int main_pics(int argc, char* argv[])
 	assert(1 == ksp_dims[MAPS_DIM]);
 
 
-	(conf.gpu ? num_init_gpu : num_init)();
+	if (conf.gpu)
+		num_init_gpu_device(gpun);
+	else
+		num_init();
 
 	// print options
 

--- a/tests/pics.mk
+++ b/tests/pics.mk
@@ -70,8 +70,10 @@ tests/test-pics-bpwavl1: scale fft noise fmac ones pics nrmse $(TESTS_OUT)/shepp
 	$(TOOLDIR)/fft -u 7 shepp.ra ksp1.ra						;\
 	$(TOOLDIR)/noise -s 1 -n 1 ksp1.ra ksp2.ra					;\
 	$(TOOLDIR)/ones 3 128 128 1 o.ra						;\
-	$(TOOLDIR)/pics -P 128 -w1. -RW:3:0:1. -i50 -u 2 ksp2.ra o.ra reco.ra		;\
+	$(TOOLDIR)/pics -a -P 128 -w1. -RW:3:0:1. -i50 ksp2.ra o.ra reco.ra		;\
+	$(TOOLDIR)/pics -m -P 128 -w1. -RW:3:0:1. -i50 -u 2 ksp2.ra o.ra reco2.ra	;\
 	$(TOOLDIR)/nrmse -t 0.08 shepp.ra reco.ra					;\
+	$(TOOLDIR)/nrmse -t 0.08 shepp.ra reco2.ra					;\
 	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
 	touch $@
 


### PR DESCRIPTION
Adds the primal dual algorithm [1] for solving f(Ax) + g(x), and adds option to use it for basis pursuit denoising in pics. Includes stochastic updates as suggested by @frankong 

[1] Chambolle A, Pock, T. A First-Order Primal-Dual Algorithm for Convex Problems with Applications to Imaging. J. Math. Imaging Vis. 2011; 40, 120-145.