### PR TITLE
Added NIHT stage 3

### DIFF
--- a/src/dfwavelet/prox_dfwavelet.c
+++ b/src/dfwavelet/prox_dfwavelet.c
@@ -273,7 +273,7 @@ struct prox_4pt_dfwavelet_data* prepare_prox_4pt_dfwavelet_data(const long im_di
 	long strs[DIMS];
 	md_calc_strides(DIMS, strs, data->tim_dims, CFL_SIZE);
 
-	data->w_op = linop_wavelet_create(DIMS, FFT_FLAGS, data->tim_dims, strs, min_size);
+	data->w_op = linop_wavelet_create(DIMS, FFT_FLAGS, data->tim_dims, strs, min_size, false);
         data->wthresh_op = prox_unithresh_create(DIMS, data->w_op, lambda, MD_BIT(data->flow_dim), use_gpu);
 
         return PTR_PASS(data);

--- a/src/iter/iter.h
+++ b/src/iter/iter.h
@@ -137,7 +137,7 @@ struct iter_niht_conf {
 
 	unsigned int maxiter;
 	float tol;
-	_Bool do_warmstart;	
+	_Bool do_warmstart;
 };
 
 extern DEF_TYPEID(iter_niht_conf);

--- a/src/iter/thresh.c
+++ b/src/iter/thresh.c
@@ -101,7 +101,8 @@ static void hardthresh_apply(const operator_data_t* _data,  float mu, complex fl
 	UNUSED(mu);
 	const struct thresh_s* data = CAST_DOWN(thresh_s, _data);
 
-	md_zhardthresh2(data->D, data->dim, data->k, data->flags, data->tmp_norm, data->str, optr, data->str, iptr);
+	//only producing the support mask
+	md_zhardthresh_mask2(data->D, data->dim, data->k, data->flags, data->tmp_norm, data->str, optr, data->str, iptr);
 }
 
 

--- a/src/iter/vec.h
+++ b/src/iter/vec.h
@@ -20,7 +20,7 @@ struct vec_iter_s {
 	void (*xpay)(long N, float alpha, float* a, const float* x);
 	void (*axpy)(long N, float* a, float alpha, const float* x);
 	void (*axpbz)(long N, float* out, const float a, const float* x, const float b, const float* z);
-	void (*nzsupport)(long N, float* out, const float* in);
+	void (*zmul)(long N, _Complex float* dst, const _Complex float* src1, const _Complex float* src2);
 };
 
 #ifdef USE_CUDA

--- a/src/linops/waveop.c
+++ b/src/linops/waveop.c
@@ -5,6 +5,7 @@
  *
  * Authors:
  * 2014-2017 Martin Uecker <martin.uecker@med.uni-goettingen.de>
+ * 2017 Sofia Dimoudi <sofia.dimoudi@cardiov.ox.ac.uk>
  */
 
 #include <assert.h>
@@ -32,30 +33,52 @@ struct wavelet_s {
 	const long* odims;
 	const long* ostr;
 	const long* minsize;
+	long* shifts;
+	bool randshift;
+	int rand_state;
 };
 
 static DEF_TYPEID(wavelet_s);
+
+static int wrand_lim(unsigned int* state, int limit)
+{
+        int divisor = RAND_MAX / (limit + 1);
+        int retval;
+
+        do {
+                retval = rand_r(state) / divisor;
+
+        } while (retval > limit);
+
+        return retval;
+}
 
 static void wavelet_forward(const linop_data_t* _data, complex float* dst, const complex float* src)
 {
 	const struct wavelet_s* data = CAST_DOWN(wavelet_s, _data);
 
-	long shifts[data->N];
-	for (unsigned int i = 0; i < data->N; i++)
-		shifts[i] = 0;
+	if (data->randshift) {
 
-	fwt2(data->N, data->flags, shifts, data->odims, data->ostr, dst, data->idims, data->istr, src, data->minsize, 4, wavelet_dau2);
+		for (unsigned int i = 0; i < data->N; i++) {
+
+			if (MD_IS_SET(data->flags, i)) {
+
+				int levels = wavelet_num_levels(data->N, MD_BIT(i), data->idims, data->minsize, 4);
+				data->shifts[i] = wrand_lim((unsigned int*)&data->rand_state, 1 << levels);
+
+				assert(data->shifts[i] < data->idims[i]);
+			}
+		}
+	}
+
+	fwt2(data->N, data->flags, data->shifts, data->odims, data->ostr, dst, data->idims, data->istr, src, data->minsize, 4, wavelet_dau2);
 }
 
 static void wavelet_adjoint(const linop_data_t* _data, complex float* dst, const complex float* src)
 {
 	const struct wavelet_s* data = CAST_DOWN(wavelet_s, _data);
 
-	long shifts[data->N];
-	for (unsigned int i = 0; i < data->N; i++)
-		shifts[i] = 0;
-
-	iwt2(data->N, data->flags, shifts, data->idims, data->istr, dst, data->odims, data->ostr, src, data->minsize, 4, wavelet_dau2);
+	iwt2(data->N, data->flags, data->shifts, data->idims, data->istr, dst, data->odims, data->ostr, src, data->minsize, 4, wavelet_dau2);
 }
 
 static void wavelet_del(const linop_data_t* _data)
@@ -67,17 +90,20 @@ static void wavelet_del(const linop_data_t* _data)
 	xfree(data->idims);
 	xfree(data->istr);
 	xfree(data->minsize);
+	xfree(data->shifts);
 
 	xfree(data);
 }
 
-struct linop_s* linop_wavelet_create(unsigned int N, unsigned int flags, const long dims[N], const long istr[N], const long minsize[N])
+struct linop_s* linop_wavelet_create(unsigned int N, unsigned int flags, const long dims[N], const long istr[N], const long minsize[N], bool randshift)
 {
 	PTR_ALLOC(struct wavelet_s, data);
 	SET_TYPEID(wavelet_s, data);
 
 	data->N = N;
 	data->flags = flags;
+	data->randshift = randshift;
+	data->rand_state = 1;
 
 	long (*idims)[N] = TYPE_ALLOC(long[N]);
 	md_copy_dims(N, *idims, dims);
@@ -91,7 +117,6 @@ struct linop_s* linop_wavelet_create(unsigned int N, unsigned int flags, const l
 	md_copy_dims(N, *nminsize, minsize);
 	data->minsize = *nminsize;
 
-
 	long (*odims)[N] = TYPE_ALLOC(long[N]);
 	wavelet_coeffs2(N, flags, *odims, dims, minsize, 4);
 	data->odims = *odims;
@@ -100,6 +125,10 @@ struct linop_s* linop_wavelet_create(unsigned int N, unsigned int flags, const l
 	md_calc_strides(N, *ostr, *odims, CFL_SIZE);
 	data->ostr = *ostr;
 
+	long (*shifts)[N] = TYPE_ALLOC(long[N]);
+	for (unsigned int i = 0; i < data->N; i++)
+		(*shifts)[i] = 0;
+	data->shifts = *shifts;
 
 	return linop_create2(N, *odims, *ostr, N, dims, istr, CAST_UP(PTR_PASS(data)), wavelet_forward, wavelet_adjoint, NULL, NULL, wavelet_del);
 }

--- a/src/linops/waveop.h
+++ b/src/linops/waveop.h
@@ -5,7 +5,7 @@
 
 #include "misc/cppwrap.h"
 
-extern struct linop_s* linop_wavelet_create(unsigned int N, unsigned int flags, const long dims[__VLA(N)], const long istr[__VLA(N)], const long minsize[__VLA(N)]);
+extern struct linop_s* linop_wavelet_create(unsigned int N, unsigned int flags, const long dims[__VLA(N)], const long istr[__VLA(N)], const long minsize[__VLA(N)], _Bool randshift);
 
 #include "misc/cppwrap.h"
 

--- a/src/num/flpmath.h
+++ b/src/num/flpmath.h
@@ -153,9 +153,14 @@ extern void md_zsoftthresh_core2(unsigned int D, const long dims[__VLA(D)], floa
 extern void md_zsoftthresh2(unsigned int D, const long dim[__VLA(D)], float lambda, unsigned int flags, const long ostr[__VLA(D)], _Complex float* optr, const long istr[__VLA(D)], const _Complex float* iptr);
 extern void md_zsoftthresh(unsigned int D, const long dim[__VLA(D)], float lambda, unsigned int flags, _Complex float* optr, const _Complex float* iptr);
 
-extern void md_zhardthresh2(unsigned int D, const long dims[__VLA(D)], unsigned int k, unsigned int flags, _Complex float* tmp_norm, const long ostrs[__VLA(D)], _Complex float* optr, const long istrs[__VLA(D)], const _Complex float* iptr);
-extern void md_zhardthresh(unsigned int D, const long dims[__VLA(D)], unsigned int k, unsigned int flags, _Complex float* optr, const _Complex float* iptr);
+void md_zhardthresh_mask2(unsigned int D, const long dim[__VLA(D)], unsigned int k, unsigned int flags, _Complex float* tmp_norm, const long ostr[__VLA(D)], _Complex float* optr, const long istr[__VLA(D)], const _Complex float* iptr);
 
+extern void md_zhardthresh_mask(unsigned int D, const long dim[__VLA(D)], unsigned int k, unsigned int flags, _Complex float* optr, const _Complex float* iptr);
+
+extern void md_zhardthresh_joint2(unsigned int D, const long dims[__VLA(D)], unsigned int k, unsigned int flags, _Complex float* tmp_norm, const long ostrs[__VLA(D)], _Complex float* optr, const long istrs[__VLA(D)], const _Complex float* iptr);
+
+extern void md_zhardthresh2(unsigned int D, const long dims[__VLA(D)], unsigned int k, unsigned int flags, const long ostrs[__VLA(D)], _Complex float* optr, const long istrs[__VLA(D)], const _Complex float* iptr);
+extern void md_zhardthresh(unsigned int D, const long dims[__VLA(D)], unsigned int k, unsigned int flags, _Complex float* optr, const _Complex float* iptr);
 
 extern void md_zconj(unsigned int D, const long dim[__VLA(D)], _Complex float* optr, const _Complex float* iptr);
 extern void md_zconj2(unsigned int D, const long dim[__VLA(D)], const long ostr[__VLA(D)], _Complex float* optr, const long istr[__VLA(D)], const _Complex float* iptr);

--- a/src/num/vecops.h
+++ b/src/num/vecops.h
@@ -61,7 +61,7 @@ struct vec_ops {
 	void (*softthresh)(long N, float lambda,  float* dst, const float* src);
 //	void (*swap)(long N, float* a, float* b);
 	void (*zhardthresh)(long N,  unsigned int k, _Complex float* d, const _Complex float* x);
-	void (*nzsupport)(long N, float* out, const float* in);
+	void (*zhardthresh_mask)(long N,  unsigned int k, _Complex float* d, const _Complex float* x);
 };
 
 

--- a/src/pics.c
+++ b/src/pics.c
@@ -621,6 +621,9 @@ int main_pics(int argc, char* argv[])
 
 			italgo = iter2_niht;
 			iconf = CAST_UP(&ihconf);
+
+			conf.gpu = false; // gpu not implemented, disable
+
 			break;		
 
 		default:			

--- a/src/pocsense.c
+++ b/src/pocsense.c
@@ -134,7 +134,7 @@ int main_pocsense(int argc, char* argv[])
 		long strs[DIMS];
 		md_calc_strides(DIMS, strs, ksp_dims, CFL_SIZE);
 
-		wave_op = linop_wavelet_create(DIMS, FFT_FLAGS, ksp_dims, strs, minsize);
+		wave_op = linop_wavelet_create(DIMS, FFT_FLAGS, ksp_dims, strs, minsize, false);
 		thresh_op = prox_unithresh_create(DIMS, wave_op, alpha, COIL_FLAG, use_gpu);
 	}
 #if 0

--- a/src/threshold.c
+++ b/src/threshold.c
@@ -55,7 +55,7 @@ static void wthresh(unsigned int D, const long dims[D], float lambda, unsigned i
 	long strs[D];
 	md_calc_strides(D, strs, dims, CFL_SIZE);
 
-	const struct linop_s* w = linop_wavelet_create(D, wflags, dims, strs, minsize);
+	const struct linop_s* w = linop_wavelet_create(D, wflags, dims, strs, minsize, false);
 	const struct operator_p_s* p = prox_unithresh_create(D, w, lambda, flags, false);
 
 	operator_p_apply(p, 1., D, dims, out, D, dims, in);

--- a/src/wavelet.c
+++ b/src/wavelet.c
@@ -81,7 +81,7 @@ int main_wavelet(int argc, char* argv[])
 	long strs[N];
 	md_calc_strides(N, strs, dims, CFL_SIZE);
 
-	const struct linop_s* w = linop_wavelet_create(N, flags, dims, strs, minsize);
+	const struct linop_s* w = linop_wavelet_create(N, flags, dims, strs, minsize, false);
 
 	long odims[N];
 	md_copy_dims(N, odims, (adj ? linop_domain : linop_codomain)(w)->dims);


### PR DESCRIPTION
3rd part of the NIHT reconstruction implementation.

Main Changes:
Added joint wavelet thresholding (grecon/optreg.c, num/flpmath.c)
Changed thresholding application into producing hard threshold support mask which is applied separately with vector element-wise multiplication (iter/niht.c)
Changed zhardthresh functions structure to separate in mask making, full application, joint application (num/flpmath.c)
Replaced nzsupport with zhardthresh_mask (num/vecops.c)
Added random shift to wavelet linear operator (linops/waveop.c)
explicitly disable GPU switch when NIHT is selected (pics.c, grecon/optreg.c)
Minor adjustments to related files to suit the changes.


