### PR TITLE
nlinv: fix GPU reconstruction

### DIFF
--- a/src/nlinv.c
+++ b/src/nlinv.c
@@ -177,11 +177,9 @@ int main_nlinv(int argc, char* argv[])
 
 		complex float* kspace_gpu = md_alloc_gpu(DIMS, ksp_dims, CFL_SIZE);
 		md_copy(DIMS, ksp_dims, kspace_gpu, kspace_data, CFL_SIZE);
-		noir_recon(&conf, dims, img, NULL, pattern, mask, kspace_gpu);
+
+		noir_recon(&conf, dims, img, sens, pattern, mask, kspace_gpu);
 		md_free(kspace_gpu);
-
-		md_zfill(DIMS, ksp_dims, sens, 1.);
-
 	} else
 #endif
 	noir_recon(&conf, dims, img, sens, pattern, mask, kspace_data);

--- a/src/noir/recon.c
+++ b/src/noir/recon.c
@@ -98,8 +98,14 @@ void noir_recon(const struct noir_conf_s* conf, const long dims[DIMS], complex f
 
 	if (NULL != sens ) {
 
-		assert(!conf->usegpu);
-		noir_forw_coils(noir_get_data(nlop), sens, x + skip);
+#ifdef USE_CUDA
+		if (conf->usegpu) {
+
+			noir_forw_coils(noir_get_data(nlop), x + skip, x + skip);
+			md_copy(DIMS, coil_dims, sens, x + skip, CFL_SIZE);
+		} else
+#endif
+			noir_forw_coils(noir_get_data(nlop), sens, x + skip);
 		fftmod(DIMS, coil_dims, fft_flags, sens, sens);
 	}
 


### PR DESCRIPTION
Hi,

apparently I made a mistake when splitting my commit into the series:
Commit 928ff3a5795c965b83a09211db1f0d6f6289d66d contains a bad mistake: After that commit, `noir_recon` copies the initial sensitivites from its argument `sens`. But in GPU reconstruction, we still pass NULL there, creating a segfault.

This later patch in the series fixes it, by passing `sens` to `noir_recon` even when doing GPU reconstruction. Additionally, it enables sensitivity output for that case.

Seems like we need a GPU test for nlinv...