### PR TITLE
vecops: add smax for scalar max

### DIFF
--- a/src/num/flpmath.c
+++ b/src/num/flpmath.c
@@ -1,4 +1,4 @@
-/* Copyright 2013-2015 The Regents of the University of California.
+/* Copyright 2013-2018 The Regents of the University of California.
  * Copyright 2016-2017. Martin Uecker.
  * Copyright 2017. University of Oxford.
  * All rights reserved. Use of this source code is governed by
@@ -8,7 +8,7 @@
  * 2012-2017 Martin Uecker <martin.uecker@med.uni-goettingen.de>
  * 2013 Dara Bahri <dbahri123@gmail.com>
  * 2014 Frank Ong <frankong@berkeley.edu>
- * 2014-2015 Jonathan Tamir <jtamir@eecs.berkeley.edu>
+ * 2014-2018 Jonathan Tamir <jtamir@eecs.berkeley.edu>
  * 2016 Siddharth Iyer <sid8795@gmail.com>
  * 2017 Sofia Dimoudi <sofia.dimoudi@cardiov.ox.ac.uk>
  *
@@ -3148,12 +3148,25 @@ void md_smin(unsigned int D, const long dim[D], float* optr, const float* iptr, 
 void md_smax2(unsigned int D, const long dim[D], const long ostr[D], float* optr, const long istr[D], const float* iptr, float val)
 {
 #if 0
+	// slow on GPU due to make_3op_scalar
+#if 0
 	float* tmp = md_alloc_sameplace(D, dim, FL_SIZE, iptr);
 	md_sgreatequal2(D, dim, ostr, tmp, istr, iptr, val);
 	md_mul2(D, dim, ostr, optr, istr, iptr, istr, tmp);
 	md_free(tmp);
 #else
 	make_3op_scalar(md_max2, D, dim, ostr, optr, istr, iptr, val);
+#endif
+#else
+	(void)0;
+
+	NESTED(void, nary_smax, (struct nary_opt_data_s* data, void* ptr[]))
+	{
+		data->ops->smax(data->size, ptr[0], ptr[1], val);
+	};
+
+	optimized_twoop_oi(D, dim, ostr, optr, istr, iptr,
+		(size_t[2]){ FL_SIZE, FL_SIZE }, nary_smax);
 #endif
 }
 

--- a/src/num/gpukrnls.cu
+++ b/src/num/gpukrnls.cu
@@ -1,10 +1,10 @@
-/* Copyright 2013-2017. The Regents of the University of California.
+/* Copyright 2013-2018. The Regents of the University of California.
  * All rights reserved. Use of this source code is governed by 
  * a BSD-style license which can be found in the LICENSE file.
  *
  * Authors:
  * 2012-03-24 Martin Uecker <uecker@eecs.berkeley.edu>
- * 2015,2017 Jon Tamir <jtamir@eecs.berkeley.edu>
+ * 2015-2018 Jon Tamir <jtamir@eecs.berkeley.edu>
  *
  * 
  * This file defines basic operations on vectors of floats/complex floats
@@ -731,6 +731,22 @@ extern "C" void cuda_zfftmod(long N, _Complex float* dst, const _Complex float* 
 
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
+
+
+__global__ void kern_smax(int N, float* dst, const float* src1, const float val)
+{
+	int start = threadIdx.x + blockDim.x * blockIdx.x;
+	int stride = blockDim.x * gridDim.x;
+
+	for (int i = start; i < N; i += stride)
+		dst[i] = MAX(src1[i], val);
+}
+
+
+extern "C" void cuda_smax(long N, float* dst, const float* src1, const float val)
+{
+	kern_smax<<<gridsize(N), blocksize(N)>>>(N, dst, src1, val);
+}
 
 
 __global__ void kern_max(int N, float* dst, const float* src1, const float* src2)

--- a/src/num/gpukrnls.h
+++ b/src/num/gpukrnls.h
@@ -1,4 +1,4 @@
-/* Copyright 2013-2017. The Regents of the University of California.
+/* Copyright 2013-2018. The Regents of the University of California.
  * All rights reserved. Use of this source code is governed by 
  * a BSD-style license which can be found in the LICENSE file.
  */
@@ -44,6 +44,7 @@ extern void cuda_zcmp(long N, _Complex float* dst, const _Complex float* src1, c
 extern void cuda_zdiv_reg(long N, _Complex float* dst, const _Complex float* src1, const _Complex float* src2, _Complex float lambda);
 extern void cuda_le(long N, float* dst, const float* src1, const float* src2);
 extern void cuda_zfftmod(long N, _Complex float* dst, const _Complex float* src, unsigned int n, _Bool inv, double phase);
+extern void cuda_smax(long N, float* dst, const float* src1, const float val);
 extern void cuda_max(long N, float* dst, const float* src1, const float* src2);
 extern void cuda_min(long N, float* dst, const float* src1, const float* src2);
 

--- a/src/num/gpuops.c
+++ b/src/num/gpuops.c
@@ -1,4 +1,4 @@
-/* Copyright 2013-2017. The Regents of the University of California.
+/* Copyright 2013-2018. The Regents of the University of California.
  * Copyright 2014. Joseph Y Cheng.
  * Copyright 2016. Martin Uecker.
  * All rights reserved. Use of this source code is governed by
@@ -7,7 +7,7 @@
  * Authors: 
  * 2012-2016	Martin Uecker <martin.uecker@med.uni-goettingen.de>
  * 2014 	Joseph Y Cheng <jycheng@stanford.edu>
- * 2015,2017		Jon Tamir <jtamir@eecs.berkeley.edu>
+ * 2015-2018	Jon Tamir <jtamir@eecs.berkeley.edu>
  *
  * 
  * CUDA support functions. The file exports gpu_ops of type struct vec_ops
@@ -356,6 +356,7 @@ const struct vec_ops gpu_ops = {
 	.zdiv_reg = cuda_zdiv_reg,
 	.zfftmod = cuda_zfftmod,
 
+	.smax = cuda_smax,
 	.max = cuda_max,
 	.min = cuda_min,
 

--- a/src/num/vecops.c
+++ b/src/num/vecops.c
@@ -1,4 +1,4 @@
-/* Copyright 2013-2017. The Regents of the University of California.
+/* Copyright 2013-2018. The Regents of the University of California.
  * Copyright 2016. Martin Uecker.
  * Copyright 2017. University of Oxford.
  * All rights reserved. Use of this source code is governed by
@@ -7,7 +7,7 @@
  * Authors:
  * 2011-2016 Martin Uecker <martin.uecker@med.uni-goettingen.de>
  * 2014 Frank Ong <frankong@berkeley.edu>
- * 2014-2017 Jon Tamir <jtamir@eecs.berkeley.edu>
+ * 2014-2018 Jon Tamir <jtamir@eecs.berkeley.edu>
  * 2017 Sofia Dimoudi <sofia.dimoudi@cardiov.ox.ac.uk>
  *
  *
@@ -328,6 +328,12 @@ static void max(long N, float* dst, const float* src1, const float* src2)
 		dst[i] = MAX(src1[i], src2[i]);
 }
 
+static void smax(long N, float* dst, const float* src1, const float val)
+{
+	for (long i = 0; i < N; i++)
+		dst[i] = MAX(src1[i], val);
+}
+
 
 static void min(long N, float* dst, const float* src1, const float* src2)
 {
@@ -576,6 +582,7 @@ const struct vec_ops cpu_ops = {
 	.zdiv_reg = zdiv_reg,
 	.zfftmod = zfftmod,
 
+	.smax = smax,
 	.max = max,
 	.min = min,
 

--- a/src/num/vecops.h
+++ b/src/num/vecops.h
@@ -55,6 +55,7 @@ struct vec_ops {
 	void (*zdiv_reg)(long N, _Complex float* dst, const _Complex float* src1, const _Complex float* src2, _Complex float lambda);
 	void (*zfftmod)(long N, _Complex float* dst, const _Complex float* src, unsigned int n, _Bool inv, double phase);
 
+	void (*smax)(long N, float* dst, const float* src1, const float val);
 	void (*max)(long N, float* dst, const float* src1, const float* src2);
 	void (*min)(long N, float* dst, const float* src1, const float* src2);
 


### PR DESCRIPTION
Adds a scalar max vector op. This is necessary because the version which casts the scalar (md_smax) to the more general case (md_max) results in extremely poor performance for GPU (millisecond calculation compared to tens of seconds)