### PR TITLE
Update mat2cfl for new Matlab interleaved complex API

### DIFF
--- a/src/mat2cfl.c
+++ b/src/mat2cfl.c
@@ -1,6 +1,9 @@
 /*
  * Martin Uecker 2012-01-18
  * uecker@eecs.berkeley.edu
+ *
+ * Damien Nguyen 2018-04-19
+ * damien.nguyen@alumni.epfl.ch
  */
 
 #include <string.h>
@@ -70,13 +73,20 @@ int main(int argc, char *argv[])
 		snprintf(outname, 256, "%s_%s", strtok(argv[1], "."), name);
 
 		complex float* buf = create_cfl(outname, ndim, ldims);
+		size_t size = md_calc_size(ndim, ldims);
+
+#if MX_HAS_INTERLEAVED_COMPLEX
+		mxComplexDouble* x = mxGetComplexDoubles(ar);
+
+		for (unsigned long i = 0; i < size; i++) 
+			buf[i] = x[i].real + 1.i * x[i].imag;
+#else
 		double* re = mxGetPr(ar);
 		double* im = mxGetPi(ar);
 
-		size_t size = md_calc_size(ndim, ldims);
-
 		for (unsigned long i = 0; i < size; i++) 
 			buf[i] = re[i] + 1.i * im[i];
+#endif /* MX_HAS_INTERLEAVED_COMPLEX */
 
 		printf("] -> %s\n", outname);
 


### PR DESCRIPTION
As the title mentions, adds support for the new Matlab interleaved complex C API (from R2018a onwards)