### PR TITLE
Added wave-shuffling + fixes wavepsf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ MODULES_lrmatrix = -llowrank -liter -llinops
 MODULES_estdims = -lnoncart -llinops
 MODULES_ismrmrd = -lismrm
 MODULES_wavelet = -llinops -lwavelet
+MODULES_wshfl = -llinops -lwavelet -liter -llowrank -llinops
 
 
 MAKEFILES = $(root)/Makefiles/Makefile.*

--- a/build_targets.mk
+++ b/build_targets.mk
@@ -3,7 +3,7 @@
 TBASE=show slice crop resize join transpose squeeze flatten zeros ones flip circshift extract repmat bitmask reshape version delta copy casorati vec
 TFLP=scale invert conj fmac saxpy sdot spow cpyphs creal carg normalize cdf97 pattern nrmse mip avg cabs zexpj
 TNUM=fft fftmod fftshift noise bench threshold conv rss filter mandelbrot wavelet window var std
-TRECO=pics pocsense sqpics itsense nlinv nufft rof sake wave lrmatrix estdims estshift estdelay wavepsf
+TRECO=pics pocsense sqpics itsense nlinv nufft rof sake wave lrmatrix estdims estshift estdelay wavepsf wshfl
 TCALIB=ecalib ecaltwo caldir walsh cc ccapply calmat svd estvar whiten
 TMRI=homodyne poisson twixread fakeksp
 TSIM=phantom traj

--- a/src/wavepsf.c
+++ b/src/wavepsf.c
@@ -1,9 +1,9 @@
-/* Copyright 2017. Massachusetts Institute of Technology.
+/* Copyright 2017-2018. Massachusetts Institute of Technology.
  * All rights reserved. Use of this source code is governed by
  * a BSD-style license which can be found in the LICENSE file.
  *
  * Authors:
- * 2017 Siddharth Iyer <ssi@mit.edu>
+ * 2017-2018 Siddharth Iyer <ssi@mit.edu>
  *
  * Bilgic B, Gagoski BA, Cauley SF, Fan AP, Polimeni JR, Grant PE, Wald LL, Setsompop K. 
  * Wave‐CAIPI for highly accelerated 3D imaging. Magnetic resonance in medicine. 
@@ -31,47 +31,49 @@
 #define LARMOR 4257.56
 #endif
 
-
 static const char usage_str[] = "<output>";
-static const char help_str[] = "Generate the wave PSF in hybrid space.\n"
+static const char help_str[] = "Generate a wave PSF in hybrid space.\n"
 															 "- Assumes the first dimension is the readout dimension.\n"
-															 "- Assumes Gy and Gz gradients have idential max\n"
-															 "	amplitude and slew rate.\n"
-                               "Example:\n"
-                               "bart wavepsf -x 768 -y 256 -z 1 -p 0.1 -q 0.1 -a 3000 -t 0.00001 -g 4 -s 18000 -n 6 wave_psf\n";
+															 "- Only generates a 2 dimensional PSF.\n"
+															 "- Use reshape and fmac to generate a 3D PSF.\n\n"
+															 "3D PSF Example:\n"
+															 "bart wavepsf		-x 768 -y 128 -r 0.1 -a 3000 -t 0.00001 -g 0.8 -s 17000 -n 6 wY\n"
+															 "bart wavepsf -c -x 768 -y 128 -r 0.1 -a 3000 -t 0.00001 -g 0.8 -s 17000 -n 6 wZ\n"
+															 "bart reshape 7 wZ 768 1 128 wZ wZ\n"
+															 "bart fmac wY wZ wYZ";
 
 int main_wavepsf(int argc, char* argv[])
 {
 	
 	// Spatial dimensions.
-	int sx = 512;				// Number of readout points. Size of dimension 0.
-	int sy = 128;				// Number of phase encode 1 points. Size of dimension 1.
-	int sz = 1;					// Number of phase encode 2 points. Size of dimension 2.
-	float dy = 0.1;			// Resolution in the phase encode 1 direction in cm.
-	float dz = 0.1;			// Resolution in the phase encode 2 direction in cm.
+	int sx = 512;				// Number of readout points.
+	int sy = 128;				// Number of phase encode points.
+	float dy = 0.1;			// Resolution in the phase encode direction in cm.
 
 	// ADC parameters.
 	int adc = 3000;			// Readout duration in microseconds.
 	float dt = 1e-5;		// ADC sampling rate in seconds.
 
 	// Gradient parameters.
-	float gmax = 4;			// Maximum gradient amplitude in Gauss per centimeter.
-	float smax = 18000; // Maximum slew rate in Gauss per centimeter per second.
+	float gmax = 0.8;		// Maximum gradient amplitude in Gauss per centimeter.
+	float smax = 17000; // Maximum slew rate in Gauss per centimeter per second.
 
 	// Wave parameters.
 	int ncyc = 6;				// Number of gradient sine-cycles.
 
+	// Sine wave or cosine wave.
+	bool cs = false;		// Set to true to use a cosine gradient wave/
+
 	const struct opt_s opts[] = {
-		OPT_INT('x', &sx, "DIM_ro", "Number of readout points or numel(dim 0)"),
-		OPT_INT('y', &sy, "DIM_pe1", "Number of phase encode 1 points or numel(dim 1)"),
-		OPT_INT('z', &sz, "DIM_pe2", "Number of phase encode 2 points or numel(dim 2)"),
-		OPT_FLOAT('p', &dy, "RES_pe1", "Resolution in phase encode 1 (centimeters)"),
-		OPT_FLOAT('q', &dz, "RES_pe2", "Resolution in phase encode 2 (centimeters)"),
-		OPT_INT('a', &adc, "ADC_duration", "Readout duration in microseconds."),
-		OPT_FLOAT('t', &dt, "ADC_dt", "ADC sampling rate in seconds"),
-		OPT_FLOAT('g', &gmax, "GRAD_maxamp", "Maximum gradient amplitude in Gauss/cm"),
-		OPT_FLOAT('s', &smax, "GRAD_maxslew", "Maximum gradient slew rate in Gauss/cm/second"),
-		OPT_INT('n', &ncyc, "WAVE_cycles", "Number of cycles in the gradient sine wave."),
+		OPT_SET(	'c', &cs,							"Set to use a cosine gradient wave"),
+		OPT_INT(	'x', &sx,		"RO_dim", "Number of readout points"),
+		OPT_INT(	'y', &sy,		"PE_dim", "Number of phase encode points"),
+		OPT_FLOAT('r', &dy,		"PE_res", "Resolution of phase encode in cm"),
+		OPT_INT(	'a', &adc,	"ADC_T",	"Readout duration in microseconds."),
+		OPT_FLOAT('t', &dt,		"ADC_dt", "ADC sampling rate in seconds"),
+		OPT_FLOAT('g', &gmax, "gMax",		"Maximum gradient amplitude in Gauss/cm"),
+		OPT_FLOAT('s', &smax, "sMax",		"Maximum gradient slew rate in Gauss/cm/second"),
+		OPT_INT(	'n', &ncyc, "ncyc",		"Number of cycles in the gradient wave"),
 	};
 
 	cmdline(&argc, argv, 1, 1, usage_str, help_str, ARRAY_SIZE(opts), opts);
@@ -84,12 +86,12 @@ int main_wavepsf(int argc, char* argv[])
 	float T = wavepoints * dt/ncyc; // Time period of the sine wave.
 	float w = 2 * M_PI/T;						// Frequency in radians per second.
 
-	/* Calculating the sine-amplitude to use. It is ether slew limited or gradient 
+	/* Calculating the wave-amplitude to use. It is either slew limited or gradient 
 		 amplitude limited. */
 	float gamp = (smax >= w * gmax) ? gmax : smax/w;
 	float gwave[wavepoints];
 	for (int tdx = 0; tdx < wavepoints; tdx++) {
-		gwave[tdx] = gamp * sin(w * tdx * dt);
+		gwave[tdx] = gamp * ((cs) ? cos(w * tdx * dt) : sin(w * tdx * dt));
 	}
 	
 	complex float phasepercm[wavepoints];
@@ -121,23 +123,20 @@ int main_wavepsf(int argc, char* argv[])
 	float scale = sqrt((float) sx/wavepoints);
 	md_zsmul(1, interp_dims, phasepercm_interp, phasepercm_interp_real, scale);
 
-	complex float psf[sz][sy][sx]; //Dimensions reversed to be consistent with cfl
+	complex float psf[sy][sx];
 
 	int midy = sy/2;
-	int midz = sz/2;
 
 	complex float phase[sx];
 	float val;
 
 	for (int ydx = 0; ydx < sy; ydx++) {
-		for (int zdx = 0; zdx < sz; zdx++) {
-			val = -((ydx - midy) * dy + (zdx - midz) * dz);
-			md_zsmul(1, interp_dims, phase, phasepercm_interp, val);
-			md_zexpj(1, interp_dims, psf[zdx][ydx], phase);
-		}
+		val = -dy * (ydx - midy);
+		md_zsmul(1, interp_dims, phase, phasepercm_interp, val);
+		md_zexpj(1, interp_dims, psf[ydx], phase);
 	}
 
-	const long psf_dims[3] = {sx, sy, sz};
+	const long psf_dims[3] = {sx, sy, 1};
 	complex float* psf_cfl = create_cfl(argv[1], 3, psf_dims);
 	md_copy(3, psf_dims, psf_cfl, psf, sizeof(complex float));
 	unmap_cfl(3, psf_dims, psf_cfl);

--- a/src/wshfl.c
+++ b/src/wshfl.c
@@ -1,0 +1,756 @@
+/* Copyright 2018. Massachusetts Institute of Technology.
+ * All rights reserved. Use of this source code is governed by
+ * a BSD-style license which can be found in the LICENSE file.
+ *
+ * Authors: 
+ * 2018 Siddharth Iyer <ssi@mit.edu>
+ *
+ * Tamir J, Uecker M, Chen W, Lai P, Alley MT, Vasanawala SS, Lustig M. 
+ * T2 shuffling: Sharp, multicontrast, volumetric fast spin‐echo imaging. 
+ * Magnetic resonance in medicine. 2017 Jan 1;77(1):180-95.
+ *
+ * B Bilgic, BA Gagoski, SF Cauley, AP Fan, JR Polimeni, PE Grant,
+ * LL Wald, and K Setsompop, Wave-CAIPI for highly accelerated 3D
+ * imaging. Magn Reson Med (2014) doi: 10.1002/mrm.25347
+ *
+ * Iyer S, Bilgic B, Setsompop K.
+ * Faster T2 shuffling with Wave.
+ * Submitted to ISMRM 2018.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <complex.h>
+#include <math.h>
+
+#include "num/multind.h"
+#include "num/flpmath.h"
+#include "num/fft.h"
+#include "num/init.h"
+#include "num/iovec.h"
+#include "num/ops.h"
+
+#include "iter/iter.h"
+#include "iter/lsqr.h"
+#include "iter/misc.h"
+
+#include "linops/linop.h"
+#include "linops/fmac.h"
+#include "linops/someops.h"
+#include "sense/model.h"
+
+#include "misc/debug.h"
+#include "misc/mri.h"
+#include "misc/utils.h"
+#include "misc/mmio.h"
+#include "misc/misc.h"
+#include "misc/opts.h"
+
+#include "wavelet/wavthresh.h"
+#include "lowrank/lrthresh.h"
+
+static const char usage_str[] = "<maps> <wave> <phi> <reorder> <table> <output>";
+static const char help_str[] = "Perform wave-shuffling reconstruction.\n\n"
+															 "Conventions:\n"
+															 "	* (sx, sy, sz) - Spatial dimensions.\n"
+															 "	* wx					 - Extended FOV in READ_DIM due to\n"
+															 "									 wave's voxel spreading.\n"
+															 "	* (nc, md)		 - Number of channels and ESPIRiT's \n"
+															 "									 extended-SENSE model operator\n"
+															 "									 dimensions (or # of maps).\n"
+															 "	* (tf, tk)		 - Turbo-factor and the rank\n"
+															 "									 of the temporal basis used in\n"
+															 "									 shuffling.\n"
+															 "	* ntr					 - Number of TRs, or the number of\n"
+															 "									 (ky, kz) points acquired of one\n"
+															 "									 echo image.\n"
+															 "	* n						 - Total number of (ky, kz) points\n"
+															 "									 acquired. This is equal to the\n"
+															 "									 product of ntr and tf.\n\n"
+															 "Descriptions:\n"
+															 "	* reorder is an (n by 3) index matrix such that\n"
+															 "		[ky, kz, t] = reorder(i, :) represents the\n"
+															 "		(ky, kz) kspace position of the readout line\n" 
+															 "		acquired at echo number (t), and 0 <= ky < sy,\n"
+															 "		0 <= kz < sz, 0 <= t < tf).\n"
+															 "	* table is a (wx by nc by n) matrix such that\n"
+															 "		table(:, :, k) represents the kth multichannel\n"
+															 "		kspace line.\n\n"
+															 "Expected dimensions:\n"
+															 "	* maps		- (		sx, sy, sz, nc, md,  1,  1)\n"
+															 "	* wave		- (		wx, sy, sz,  1,  1,  1,  1)\n"
+															 "	* phi			- (		 1,  1,  1,  1,  1, tf, tk)\n"
+															 "	* output	- (		sx, sy, sz,  1, md,  1, tk)\n"
+															 "	* reorder - (		 n,  3,  1,  1,  1,  1,  1)\n"
+															 "	* table		- (		wx, nc,  n,  1,  1,  1,  1)";
+
+/* Helper function to print out operator dimensions. */
+static void print_opdims(const struct linop_s* op) 
+{
+	const struct iovec_s* domain	 = linop_domain(op);
+	const struct iovec_s* codomain = linop_codomain(op);
+	debug_printf(DP_INFO, "  domain: ");
+	debug_print_dims(DP_INFO, domain->N, domain->dims);
+	debug_printf(DP_INFO, "codomain: ");
+	debug_print_dims(DP_INFO, codomain->N, codomain->dims);
+}
+
+/* Construct sampling mask array from reorder tables. */
+static void construct_mask(long reorder_dims[DIMS], complex float* reorder, 
+													 long mask_dims[DIMS],		complex float* mask)
+{
+	int n  = reorder_dims[0];
+	int sy = mask_dims[1];
+	int sz = mask_dims[2];
+
+	int y = -1;
+	int z = -1;
+	int t = -1;
+	
+	for (int i = 0; i < n; i++) {
+		y = reorder[i];
+		z = reorder[i + n];
+		t = reorder[i + 2 * n];
+		mask[(y + z * sy) + t * sy * sz] = 1;
+	}
+}
+
+static DEF_TYPEID(kern_s);
+
+struct kern_s {
+	INTERFACE(linop_data_t);
+
+	unsigned int N;
+
+	long* reorder_dims; // Dimension of the index table:		( n,	3,	1,	1, 1,  1,  1,  1)
+	long* phi_dims;			// Dimension of the temporal basis: ( 1,	1,	1,	1, 1, tf, tk,  1)
+	long* table_dims;		// Dimension of the data table:			(wx, nc,	n,	1, 1,  1,  1,  1)
+	long* kernel_dims;	// Dimension of the kernel:					( 1, sy, sz,	1, 1,  1, tk, tk)
+
+	const complex float* reorder;
+	const complex float* phi;
+	const complex float* kernel;
+};
+
+/* Go to table from coefficient-kspace with memory efficiency. */
+static void kern_apply(const linop_data_t* _data, complex float* dst, const complex float* src)
+{
+	const struct kern_s* data = CAST_DOWN(kern_s, _data);
+
+	long wx = data->table_dims[0];
+	long sy = data->kernel_dims[1];
+	long sz = data->kernel_dims[2];
+	long nc = data->table_dims[1];
+	long n	= data->reorder_dims[0];
+	long tf = data->phi_dims[5];
+	long tk = data->phi_dims[6];
+
+	long input_dims[] = { [0 ... DIMS - 1] = 1 };
+	input_dims[0] = wx;
+	input_dims[1] = sy;
+	input_dims[2] = sz;
+	input_dims[3] = nc;
+	input_dims[6] = tk;
+
+	long perm_dims[] = { [0 ... DIMS - 1] = 1 };
+	perm_dims[0] = wx;
+	perm_dims[1] = nc;
+	perm_dims[3] = tk;
+	perm_dims[4] = sy;
+	perm_dims[5] = sz;
+	complex float* perm = md_alloc_sameplace(DIMS, perm_dims, CFL_SIZE, src);
+	unsigned int permute_order[DIMS] = {0, 3, 5, 6, 1, 2, 4, 7};
+	for (unsigned int i = 8; i < DIMS; i++)
+		permute_order[i] = i;
+	md_permute(DIMS, permute_order, perm_dims, perm, input_dims, src, CFL_SIZE);
+
+	long vec_dims[]			= {wx, nc, tf,	1};
+	long phi_mat_dims[] = { 1,	1, tf, tk};
+	long phi_in_dims[]	= {wx, nc,	1, tk};
+	long fmac_dims[]		= {wx, nc, tf, tk};
+	long line_dims[]		= {wx, nc,	1,	1};
+
+	complex float* vec = md_alloc_sameplace(4, vec_dims, CFL_SIZE, src);
+
+	long vec_str[4];
+	md_calc_strides(4, vec_str, vec_dims, CFL_SIZE);
+	long phi_mat_str[4];
+	md_calc_strides(4, phi_mat_str, phi_mat_dims, CFL_SIZE);
+	long phi_in_str[4];
+	md_calc_strides(4, phi_in_str, phi_in_dims, CFL_SIZE);
+	long fmac_str[4];
+	md_calc_strides(4, fmac_str, fmac_dims, CFL_SIZE);
+
+	int y = -1;
+	int z = -1;
+	int t = -1;
+
+	for (int i = 0; i < n; i ++) {
+
+		y = data->reorder[i];
+		z = data->reorder[i + n];
+		t = data->reorder[i + 2 * n];
+
+		md_clear(4, vec_dims, vec, CFL_SIZE);
+		md_zfmac2(4, fmac_dims, vec_str, vec, phi_in_str, (perm + ((wx * nc * tk) * (y + z * sy))),
+							phi_mat_str, data->phi);
+		md_copy(4, line_dims, dst + (i * wx * nc), vec + (t * wx * nc), CFL_SIZE);
+	}
+
+	md_free(perm);
+	md_free(vec);
+}
+
+/* Collapse data table into the temporal basis for memory efficiency. */
+static void kern_adjoint(const linop_data_t* _data, complex float* dst, const complex float* src)
+{
+	const struct kern_s* data = CAST_DOWN(kern_s, _data);
+
+	long wx = data->table_dims[0];
+	long sy = data->kernel_dims[1];
+	long sz = data->kernel_dims[2];
+	long nc = data->table_dims[1];
+	long n	= data->reorder_dims[0];
+	long tf = data->phi_dims[5];
+	long tk = data->phi_dims[6];
+
+	long perm_dims[] = { [0 ... DIMS - 1] = 1 };
+	perm_dims[0] = wx;
+	perm_dims[1] = nc;
+	perm_dims[3] = tk;
+	perm_dims[4] = sy;
+	perm_dims[5] = sz;
+
+	complex float* perm = md_alloc_sameplace(DIMS, perm_dims, CFL_SIZE, src);
+	md_clear(DIMS, perm_dims, perm, CFL_SIZE);
+
+	long vec_dims[]			= {wx, nc, tf,	1};
+	long phi_mat_dims[] = { 1,	1, tf, tk};
+	long phi_out_dims[] = {wx, nc,	1, tk};
+	long fmac_dims[]		= {wx, nc, tf, tk};
+	long line_dims[]		= {wx, nc,	1,	1};
+
+	complex float* vec = md_alloc_sameplace(4, vec_dims, CFL_SIZE, src);
+
+	long vec_str[4];
+	md_calc_strides(4, vec_str, vec_dims, CFL_SIZE);
+	long phi_mat_str[4];
+	md_calc_strides(4, phi_mat_str, phi_mat_dims, CFL_SIZE);
+	long phi_out_str[4];
+	md_calc_strides(4, phi_out_str, phi_out_dims, CFL_SIZE);
+	long fmac_str[4];
+	md_calc_strides(4, fmac_str, fmac_dims, CFL_SIZE);
+
+	int t = -1;
+	for (int y = 0; y < sy; y ++) {
+		for (int z = 0; z < sz; z ++) {
+
+			md_clear(4, vec_dims, vec, CFL_SIZE);
+
+			for (int i = 0; i < n; i ++) {
+				if ((y == data->reorder[i]) && (z == data->reorder[i + n])) {
+					t = data->reorder[i + 2 * n];
+					md_copy(4, line_dims, (vec + t * wx * nc), (src + i * wx * nc), CFL_SIZE);
+				}
+			}
+
+			md_zfmacc2(4, fmac_dims, phi_out_str, perm + (y + z * sy) * (wx * nc * tk), vec_str, vec, 
+				phi_mat_str, data->phi);
+		}
+	}
+
+	long out_dims[] = { [0 ... DIMS - 1] = 1 };
+	out_dims[0] = wx;
+	out_dims[1] = sy;
+	out_dims[2] = sz;
+	out_dims[3] = nc;
+	out_dims[6] = tk;
+	unsigned int permute_order[DIMS] = {0, 4, 5, 1, 6, 2, 3, 7};
+	for (unsigned int i = 8; i < DIMS; i++)
+		permute_order[i] = i;
+	md_permute(DIMS, permute_order, out_dims, dst, perm_dims, perm, CFL_SIZE);
+
+	md_free(vec);
+	md_free(perm);
+}
+
+static void kern_normal(const linop_data_t* _data, complex float* dst, const complex float* src)
+{
+	const struct kern_s* data = CAST_DOWN(kern_s, _data);
+
+	long wx = data->table_dims[0];
+	long sy = data->kernel_dims[1];
+	long sz = data->kernel_dims[2];
+	long nc = data->table_dims[1];
+	long tk = data->phi_dims[6];
+
+	long input_dims[DIMS] = { [0 ... DIMS - 1] = 1 };
+	input_dims[0] = wx;
+	input_dims[1] = sy;
+	input_dims[2] = sz;
+	input_dims[3] = nc;
+	input_dims[6] = tk;
+	long input_str[DIMS];
+	md_calc_strides(DIMS, input_str, input_dims, CFL_SIZE);
+
+	long output_dims[DIMS];
+	md_copy_dims(DIMS, output_dims, input_dims);
+	output_dims[6] =	1;
+	output_dims[7] = tk;
+	long output_str[DIMS];
+	md_calc_strides(DIMS, output_str, output_dims, CFL_SIZE);
+
+	long kernel_str[DIMS];
+	md_calc_strides(DIMS, kernel_str, data->kernel_dims, CFL_SIZE);
+
+	long fmac_dims[DIMS];
+	md_merge_dims(DIMS, fmac_dims, input_dims, data->kernel_dims);
+
+	md_clear(DIMS, output_dims, dst, CFL_SIZE);
+	md_zfmac2(DIMS, fmac_dims, output_str, dst, input_str, src, kernel_str, data->kernel);
+}
+
+static void kern_free(const linop_data_t* _data)
+{
+	const struct kern_s* data = CAST_DOWN(kern_s, _data);
+
+	xfree(data->reorder_dims);
+	xfree(data->phi_dims);
+	xfree(data->table_dims);
+	xfree(data->kernel_dims);
+
+	xfree(data);
+}
+
+static const struct linop_s* linop_kern_create(long N, 
+																							 long _reorder_dims[N], complex float* reorder,
+																							 long _phi_dims[N],			complex float* phi,
+																							 long _kernel_dims[N],	complex float* kernel,
+																							 long _table_dims[N])
+{
+	PTR_ALLOC(struct kern_s, data);
+	SET_TYPEID(kern_s, data);
+
+	data->N  = N;
+
+	PTR_ALLOC(long[N], reorder_dims);
+	PTR_ALLOC(long[N], phi_dims);
+	PTR_ALLOC(long[N], table_dims);
+	PTR_ALLOC(long[N], kernel_dims);
+
+	md_copy_dims(N, *reorder_dims, _reorder_dims);
+	md_copy_dims(N, *phi_dims,		 _phi_dims);
+	md_copy_dims(N, *table_dims,	 _table_dims);
+	md_copy_dims(N, *kernel_dims,  _kernel_dims);
+
+	data->reorder_dims = *PTR_PASS(reorder_dims);
+	data->phi_dims		 = *PTR_PASS(phi_dims);
+	data->table_dims	 = *PTR_PASS(table_dims);
+	data->kernel_dims  = *PTR_PASS(kernel_dims);
+
+	data->reorder = reorder;
+	data->phi			= phi;
+	data->kernel	= kernel;
+
+	long input_dims[DIMS] = { [0 ... DIMS - 1] = 1 };
+	input_dims[0] = _table_dims[0];
+	input_dims[1] = _kernel_dims[1];
+	input_dims[2] = _kernel_dims[2];
+	input_dims[3] = _table_dims[1];
+	input_dims[6] = _phi_dims[6];
+
+	long output_dims[DIMS] = { [0 ... DIMS - 1] = 1 };
+	output_dims[0] = _table_dims[0];
+	output_dims[1] = _table_dims[1];
+	output_dims[2] = _reorder_dims[0];
+
+	const struct linop_s* K = linop_create(N, output_dims, N, input_dims, CAST_UP(PTR_PASS(data)), 
+																				 kern_apply, kern_adjoint, kern_normal, NULL, kern_free);
+	debug_printf(DP_INFO, "KERNEL operator information.\n");
+	print_opdims(K);
+													 
+	return K;
+}
+
+/* ESPIRiT operator. */
+static const struct linop_s* linop_espirit_create(long sx, long sy, long sz, long nc, long md, long tk,
+																						complex float* maps)
+{
+	long max_dims[] = { [0 ... DIMS - 1] = 1};
+	max_dims[0] = sx;
+	max_dims[1] = sy;
+	max_dims[2] = sz;
+	max_dims[3] = nc;
+	max_dims[4] = md;
+	max_dims[6] = tk;
+
+	const struct linop_s* E = linop_fmac_create(DIMS, max_dims, MAPS_FLAG, 
+		COIL_FLAG, TE_FLAG|COEFF_FLAG, maps);
+ 
+	debug_printf(DP_INFO, "ESPIRiT operator information.\n");
+	print_opdims(E);
+													 
+	return E;
+}
+
+/* Resize operator. */
+static const struct linop_s* linop_reshape_create(long wx, long sx, long sy, long sz, long nc, long tk)
+{
+	long input_dims[] = { [0 ... DIMS - 1] = 1};
+	input_dims[0] = sx;
+	input_dims[1] = sy;
+	input_dims[2] = sz;
+	input_dims[3] = nc;
+	input_dims[6] = tk;
+	long output_dims[DIMS];
+	md_copy_dims(DIMS, output_dims, input_dims);
+	output_dims[0] = wx;
+	struct linop_s* R = linop_resize_create(DIMS, output_dims, input_dims);
+	debug_printf(DP_INFO, "RESHAPE operator information.\n");
+	print_opdims(R);
+	return R;
+}
+
+/* Fx operator. */
+static const struct linop_s* linop_fx_create(long wx, long sy, long sz, long nc, long tk)
+{
+	long dims[] = { [0 ... DIMS - 1] = 1};
+	dims[0] = wx;
+	dims[1] = sy;
+	dims[2] = sz;
+	dims[3] = nc;
+	dims[6] = tk;
+	struct linop_s* Fx = linop_fftc_create(DIMS, dims, READ_FLAG);
+	debug_printf(DP_INFO, "FX operator information.\n");
+	print_opdims(Fx);
+	return Fx;
+}
+
+/* Wave operator. */
+static const struct linop_s* linop_wave_create(long wx, long sy, long sz, long nc, long tk,
+																							 complex float* psf)
+{
+	long dims[] = { [0 ... DIMS - 1] = 1};
+	dims[0] = wx;
+	dims[1] = sy;
+	dims[2] = sz;
+	dims[3] = nc;
+	dims[6] = tk;
+	struct linop_s* W = linop_cdiag_create(DIMS, dims, FFT_FLAGS, psf);
+	debug_printf(DP_INFO, "WAVE operator information.\n");
+	print_opdims(W);
+	return W;
+}
+
+/* Fyz operator. */
+static const struct linop_s* linop_fyz_create(long wx, long sy, long sz, long nc, long tk)
+{
+	long dims[] = { [0 ... DIMS - 1] = 1};
+	dims[0] = wx;
+	dims[1] = sy;
+	dims[2] = sz;
+	dims[3] = nc;
+	dims[6] = tk;
+	struct linop_s* Fyz = linop_fftc_create(DIMS, dims, PHS1_FLAG|PHS2_FLAG);
+	debug_printf(DP_INFO, "FYZ operator information.\n");
+	print_opdims(Fyz);
+	return Fyz;
+}
+
+/* Construction sampling temporal kernel.*/
+static void construct_kernel(long mask_dims[DIMS], complex float* mask,
+														 long phi_dims[DIMS],  complex float* phi, 
+														 long kern_dims[DIMS], complex float* kern)
+{
+	long sy = mask_dims[1];
+	long sz = mask_dims[2];
+	long tf = phi_dims[5];
+	long tk = phi_dims[6];
+
+	long cvec_dims[] = { [0 ... DIMS - 1] = 1 };
+	cvec_dims[6] = tk;
+	long cvec_str[DIMS];
+	md_calc_strides(DIMS, cvec_str, cvec_dims, CFL_SIZE);
+
+	complex float cvec[tk];
+
+	long tvec_dims[] = { [0 ... DIMS - 1] = 1 };
+	tvec_dims[5] = tf;
+	long tvec_str[DIMS];
+	md_calc_strides(DIMS, tvec_str, tvec_dims, CFL_SIZE);
+
+	complex float mvec[tf];
+	complex float tvec1[tf];
+	complex float tvec2[tf];
+
+	long phi_str[DIMS];
+	md_calc_strides(DIMS, phi_str, phi_dims, CFL_SIZE);
+
+	long out_dims[] = { [0 ... DIMS - 1] = 1 };
+	out_dims[0] = tk;
+	out_dims[1] = sy;
+	out_dims[2] = sz;
+	out_dims[3] = tk;
+	complex float* out	= md_alloc_sameplace(DIMS, out_dims, CFL_SIZE, kern);
+
+	for (int y = 0; y < sy; y ++) {
+		for (int z = 0; z < sz; z ++) {
+
+			for (int t = 0; t < tf; t ++)
+				mvec[t] = mask[(y + sy * z) + (sy * sz) * t];
+
+			for (int t = 0; t < tk; t ++) {
+				cvec[t] = 1;
+
+				md_clear(DIMS, tvec_dims, tvec1, CFL_SIZE);
+				md_zfmac2(DIMS, phi_dims, tvec_str, tvec1, cvec_str, cvec, phi_str, phi);
+
+				md_clear(DIMS, tvec_dims, tvec2, CFL_SIZE);
+				md_zfmac2(DIMS, tvec_dims, tvec_str, tvec2, tvec_str, tvec1, tvec_str, mvec);
+
+				md_clear(DIMS, cvec_dims, out + y * tk + z * sy * tk + t * sy * sz * tk, CFL_SIZE);
+				md_zfmacc2(DIMS, phi_dims, cvec_str, out + y * tk + z * sy * tk + t * sy * sz * tk,
+					tvec_str, tvec2, phi_str, phi);
+
+				cvec[t] = 0;
+			}
+		}
+	}
+
+	unsigned int permute_order[DIMS] = {4, 1, 2, 5, 6, 7, 3, 0};
+	for (unsigned int i = 8; i < DIMS; i++)
+		permute_order[i] = i;
+
+	md_permute(DIMS, permute_order, kern_dims, kern, out_dims, out, CFL_SIZE);
+	md_free(out);
+}
+
+int main_wshfl(int argc, char* argv[])
+{
+	double start_time = timestamp();
+
+	float lambda	= 1E-5;
+	int		maxiter = 300;
+	int		blksize = 8;
+	float step		= 0.5;
+	float tol			= 1.E-3;
+	bool	llr			= false;
+	bool	wav			= false;
+	int		gpun		= -1;
+	bool	fista		= false;
+	float cont		= 0.1;
+							 
+	const struct opt_s opts[] = {
+		OPT_FLOAT('r', &lambda,  "lambda", "Soft threshold lambda for wavelet or locally low rank."),
+		OPT_INT(	'b', &blksize, "blkdim", "Block size for locally low rank."),
+		OPT_INT(	'i', &maxiter, "mxiter", "Maximum number of iterations."),
+		OPT_FLOAT('s', &step,		 "step",	 "Step size for iterative method."),
+		OPT_FLOAT('c', &cont,		 "cntnu",  "Continuation value for IST/FISTA."),
+		OPT_FLOAT('t', &tol,		 "tol",		 "Tolerance convergence condition for iterative method."),
+		OPT_INT(	'g', &gpun,		 "gpun",	 "Set GPU device number. If not set, use CPU."),
+		OPT_SET(	'f', &fista,						 "Reconstruct using FISTA instead of IST."),
+		OPT_SET(	'w', &wav,							 "Use wavelet."),
+		OPT_SET(	'l', &llr,							 "Use locally low rank."),
+	};
+
+	cmdline(&argc, argv, 6, 6, usage_str, help_str, ARRAY_SIZE(opts), opts);
+
+	debug_printf(DP_INFO, "Loading data... ");
+
+	long maps_dims[DIMS];
+	complex float* maps = load_cfl(argv[1], DIMS, maps_dims);
+		 
+	long wave_dims[DIMS];
+	complex float* wave = load_cfl(argv[2], DIMS, wave_dims);
+					
+	long phi_dims[DIMS];
+	complex float* phi = load_cfl(argv[3], DIMS, phi_dims);
+							 
+	long reorder_dims[DIMS];
+	complex float* reorder = load_cfl(argv[4], DIMS, reorder_dims);
+										
+	long table_dims[DIMS];
+	complex float* table = load_cfl(argv[5], DIMS, table_dims);
+	float norm = md_znorm(DIMS, table_dims, table);
+	md_zsmul(DIMS, table_dims, table, table, 1. / norm);
+
+	debug_printf(DP_INFO, "Done.\n");
+
+#ifdef USE_CUDA
+	if (gpun != -1) {
+		debug_printf(DP_INFO, "Transferring maps and wave to GPU memory... ");
+		complex float* tmp = maps;
+		maps = md_gpu_move(DIMS, maps_dims, tmp, CFL_SIZE);
+		unmap_cfl(DIMS, maps_dims, maps);
+
+		tmp = wave;
+		wave = md_gpu_move(DIMS, wave_dims, tmp, CFL_SIZE);
+		unmap_cfl(DIMS, wave_dims, wave);
+		debug_printf(DP_INFO, "Done.\n");
+	}
+#endif
+
+	int wx = wave_dims[0];
+	int sx = maps_dims[0];
+	int sy = maps_dims[1];
+	int sz = maps_dims[2];
+	int nc = maps_dims[3];
+	int md = maps_dims[4];
+	int tf = phi_dims[5];
+	int tk = phi_dims[6];
+
+	long coeff_dims[] = { [0 ... DIMS - 1] = 1 };
+	coeff_dims[0] = sx; 
+	coeff_dims[1] = sy; 
+	coeff_dims[2] = sz;
+	coeff_dims[4] = md; 
+	coeff_dims[6] = tk;
+
+#ifdef USE_CUDA
+	if (gpun != -1) 
+		num_init_gpu_device(gpun);
+	else
+		num_init();
+#else
+	num_init();
+#endif
+
+	debug_printf(DP_INFO, "Constructing sampling mask from reorder table... ");
+	long mask_dims[] = { [0 ... DIMS - 1] = 1 };
+	mask_dims[1] = sy;
+	mask_dims[2] = sz;
+	mask_dims[5] = tf;
+	complex float* mask = md_alloc_sameplace(DIMS, mask_dims, CFL_SIZE, maps);
+	construct_mask(reorder_dims, reorder, mask_dims, mask);
+	debug_printf(DP_INFO, "Done.\n");
+
+	debug_printf(DP_INFO, "Constructing sampling-temporal kernel... ");
+	long kernel_dims[] = { [0 ... DIMS - 1] = 1 };
+	kernel_dims[1] = sy;
+	kernel_dims[2] = sz;
+	kernel_dims[6] = tk;
+	kernel_dims[7] = tk;
+	complex float* kernel = md_alloc_sameplace(DIMS, kernel_dims, CFL_SIZE, maps); 
+	construct_kernel(mask_dims, mask, phi_dims, phi, kernel_dims, kernel);
+	md_free(mask);
+	debug_printf(DP_INFO, "Done.\n");
+
+	debug_printf(DP_INFO, "Creating linear operators:\n");
+	const struct linop_s* E		= linop_espirit_create(sx, sy, sz, nc, md, tk, maps);
+	const struct linop_s* R		= linop_reshape_create(wx, sx, sy, sz, nc, tk);
+	const struct linop_s* Fx	= linop_fx_create(wx, sy, sz, nc, tk);
+	const struct linop_s* W		= linop_wave_create(wx, sy, sz, nc, tk, wave);
+	const struct linop_s* Fyz = linop_fyz_create(wx, sy, sz, nc, tk);
+	const struct linop_s* K		= linop_kern_create(DIMS, reorder_dims, reorder, phi_dims, phi,
+																								kernel_dims, kernel, table_dims);
+
+	struct linop_s* A = linop_chain(linop_chain(linop_chain(linop_chain(linop_chain(
+												E, R), Fx), W), Fyz), K);
+
+	debug_printf(DP_INFO, "Forward model A information.\n");
+	print_opdims(A);
+	double maxeigen = estimate_maxeigenval(A->normal);
+	debug_printf(DP_INFO, "Maximum eigenvalue: %.2e\n", maxeigen);
+	step /= maxeigen;
+	debug_printf(DP_INFO, "Using stepsize: %.2e\n", step);
+
+	const struct operator_p_s* T = NULL;
+	long blkdims[MAX_LEV][DIMS];
+	long minsize[] = { [0 ... DIMS - 1] = 1 };
+	minsize[0] = MIN(sx, 16);
+	minsize[1] = MIN(sy, 16);
+	minsize[2] = MIN(sz, 16);
+	unsigned int WAVFLAG = (sx > 1) * READ_FLAG | (sy > 1) * PHS1_FLAG | (sz > 2) * PHS2_FLAG;
+
+	if ((wav == true) || (llr == true)) {
+		if (wav) {
+			debug_printf(DP_INFO, "Creating wavelet threshold operator... ");
+			T = prox_wavelet_thresh_create(DIMS, coeff_dims, WAVFLAG, 0u, minsize, lambda, false);
+		} else {
+			debug_printf(DP_INFO, "Creating locally low rank threshold operator... ");
+			llr_blkdims(blkdims, ~COEFF_DIM, coeff_dims, blksize);
+			T = lrthresh_create(coeff_dims, true, ~COEFF_FLAG, (const long (*)[])blkdims, 
+				lambda, false, false);
+		}
+		debug_printf(DP_INFO, "Done.\n");
+	}
+
+	italgo_fun_t italgo = NULL;
+	iter_conf*	 iconf	= NULL;
+
+	struct iter_conjgrad_conf cgconf;
+	struct iter_fista_conf		fsconf;
+	struct iter_ist_conf			isconf;
+
+	if ((wav == false) && (llr == false)) {
+		cgconf							= iter_conjgrad_defaults;
+		cgconf.maxiter			= maxiter;
+		cgconf.l2lambda			= 0;
+		cgconf.tol					= tol;
+		italgo							= iter_conjgrad;
+		iconf								= CAST_UP(&cgconf);
+		debug_printf(DP_INFO, "Using conjugate gradient.\n");
+	} else if (fista) {
+		fsconf							= iter_fista_defaults;
+		fsconf.maxiter			= maxiter;
+		fsconf.step					= step;
+		fsconf.hogwild			= false;
+		fsconf.tol					= tol;
+		fsconf.continuation = cont;
+		italgo							= iter_fista;
+		iconf								= CAST_UP(&fsconf);
+		debug_printf(DP_INFO, "Using FISTA.\n");
+	} else {
+		isconf							= iter_ist_defaults;
+		isconf.step					= step;
+		isconf.maxiter			= maxiter;
+		isconf.tol					= tol;
+		isconf.continuation = cont;
+		italgo							= iter_ist;
+		iconf								= CAST_UP(&isconf);
+		debug_printf(DP_INFO, "Using IST.\n");
+	}
+
+	debug_printf(DP_INFO, "Starting reconstruction... ");
+	complex float* recon = md_alloc_sameplace(DIMS, coeff_dims, CFL_SIZE, maps); 
+	struct lsqr_conf lsqr_conf = { 0., gpun != -1 };
+	lsqr(DIMS, &lsqr_conf, italgo, iconf, A, T, coeff_dims, recon,
+		table_dims, table, NULL);
+	debug_printf(DP_INFO, "Done.\n");
+
+	debug_printf(DP_INFO, "Cleaning up and saving result... ");
+
+	linop_free(E);
+	linop_free(R);
+	linop_free(Fx);
+	linop_free(W);
+	linop_free(Fyz);
+	linop_free(K);
+	linop_free(A);
+
+	md_free(kernel);
+	unmap_cfl(DIMS, phi_dims, phi);
+#ifdef USE_CUDA
+	if (gpun != -1) {
+		md_free(maps);
+		md_free(wave);
+	} else {
+		unmap_cfl(DIMS, maps_dims, maps);
+		unmap_cfl(DIMS, wave_dims, wave);
+	}
+#else
+	unmap_cfl(DIMS, maps_dims, maps);
+	unmap_cfl(DIMS, wave_dims, wave);
+#endif
+
+	complex float* result = create_cfl(argv[6], DIMS, coeff_dims);
+	md_copy(DIMS, coeff_dims, result, recon, CFL_SIZE);
+	unmap_cfl(DIMS, coeff_dims, result);
+	md_free(recon);
+	debug_printf(DP_INFO, "Done.\n");
+
+	double end_time = timestamp();
+	debug_printf(DP_INFO, "Total Time: %f seconds.\n", end_time - start_time);
+
+	return 0;
+}

--- a/tests/wave.mk
+++ b/tests/wave.mk
@@ -1,6 +1,6 @@
 tests/test-wave: wave wavepsf scale nrmse $(TESTS_OUT)/shepplogan.ra $(TESTS_OUT)/shepplogan_coil_ksp.ra $(TESTS_OUT)/coils.ra
 	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)                          ;\
-	$(TOOLDIR)/wavepsf -x 640 -y 128 -z 1 wave_psf.ra                     ;\
+	$(TOOLDIR)/wavepsf -x 640 -y 128 wave_psf.ra                          ;\
 	$(TOOLDIR)/fft -iu 7 $(TESTS_OUT)/shepplogan_coil_ksp.ra img.ra       ;\
 	$(TOOLDIR)/resize -c 0 640 img.ra wave_zpad.ra                        ;\
 	$(TOOLDIR)/fft -u 1 wave_zpad.ra wave_hyb.ra                          ;\


### PR DESCRIPTION
**Wavepsf**
- Change `wavepsf` to only generate a 2D wave. 
- Added option to use a sine or a cosine wave.

Later, I'll be attempting to implement the following to replace this function: https://onlinelibrary.wiley.com/doi/abs/10.1002/mrm.26499 

**Wave-Shuffling**
- Implemented Wave+Shuffling reconstruction. To do regular shuffling, instead of a wave PSF, pass in all ones.
- For memory efficiency, acquired data is loaded in as a table of only the acquired lines in kspace along with the (ky, kz) index locations. This is then squashed down with the temporal basis.
