### PR TITLE
Wave-shuffling updates + new command poly

### DIFF
--- a/build_targets.mk
+++ b/build_targets.mk
@@ -1,6 +1,6 @@
 # Main build targets
 #
-TBASE=show slice crop resize join transpose squeeze flatten zeros ones flip circshift extract repmat bitmask reshape version delta copy casorati vec
+TBASE=show slice crop resize join transpose squeeze flatten zeros ones flip circshift extract repmat bitmask reshape version delta copy casorati vec poly
 TFLP=scale invert conj fmac saxpy sdot spow cpyphs creal carg normalize cdf97 pattern nrmse mip avg cabs zexpj
 TNUM=fft fftmod fftshift noise bench threshold conv rss filter mandelbrot wavelet window var std
 TRECO=pics pocsense sqpics itsense nlinv nufft rof sake wave lrmatrix estdims estshift estdelay wavepsf wshfl

--- a/src/poly.c
+++ b/src/poly.c
@@ -24,7 +24,7 @@
 #define DIMS 16
 #endif
 
-static const char usage_str[] = "L N a0 a1 ... aN output";
+static const char usage_str[] = "L N a_0 a_1 ... a_N output";
 static const char help_str[]  = "Evaluate polynomial p(x) = a_0 + a_1 x + a_2 x^2 ... a_N x^N at x = {0, 1, ... , L - 1} where a_i are floats.";
 
 int main_poly(int argc, char* argv[])

--- a/src/poly.c
+++ b/src/poly.c
@@ -1,0 +1,60 @@
+/* Copyright 2018. Massachusetts Institute of Technology.
+ * All rights reserved. Use of this source code is governed by
+ * a BSD-style license which can be found in the LICENSE file.
+ *
+ * Authors: 
+ * 2018 Siddharth Iyer <ssi@mit.edu>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <complex.h>
+#include <string.h>
+
+#include "num/multind.h"
+#include "num/flpmath.h"
+#include "num/init.h"
+
+#include "misc/mmio.h"
+#include "misc/io.h"
+#include "misc/misc.h"
+
+#ifndef DIMS
+#define DIMS 16
+#endif
+
+static const char usage_str[] = "L N a0 a1 ... aN output";
+static const char help_str[]  = "Evaluate polynomial p(x) = a_0 + a_1 x + a_2 x^2 ... a_N x^N at x = {0, 1, ... , L - 1} where a_i are floats.";
+
+int main_poly(int argc, char* argv[])
+{
+	mini_cmdline(&argc, argv, -3, usage_str, help_str);
+
+	num_init();
+
+	int L = atoi(argv[1]);
+	int N = atoi(argv[2]);
+
+	assert(L >= 1);
+	assert(L <= 256 * 256);
+	assert(N >= 0);
+	assert(N + 1 <= L);
+	assert(argc == 5 + N);
+
+	long p_dims[] = { [0 ... DIMS - 1] = 1 };
+	p_dims[0] = L;
+	complex float* p = create_cfl(argv[argc - 1], DIMS, p_dims);
+	md_clear(DIMS, p_dims, p, CFL_SIZE);
+
+	for (int x = 0; x < L; x++) {
+		p[x] = (complex float) atof(argv[3]);
+		for (int n = 1; n < N + 1; n++) {
+			p[x] += ((complex float) atof(argv[3 + n])) * cpowf(x, n);
+		}
+	}
+
+	unmap_cfl(N, p_dims, p);
+
+	return 0;
+}

--- a/src/wshfl.c
+++ b/src/wshfl.c
@@ -102,18 +102,18 @@ static void construct_mask(
 	long reorder_dims[DIMS], complex float* reorder, 
 	long mask_dims[DIMS],    complex float* mask)
 {
-	int n  = reorder_dims[0];
-	int sy = mask_dims[1];
-	int sz = mask_dims[2];
+	long n  = reorder_dims[0];
+	long sy = mask_dims[1];
+	long sz = mask_dims[2];
 
-	int y = -1;
-	int z = -1;
-	int t = -1;
+	long y = 0;
+	long z = 0;
+	long t = 0;
 
 	for (int i = 0; i < n; i++) {
-		y = reorder[i];
-		z = reorder[i + n];
-		t = reorder[i + 2 * n];
+		y = lround(creal(reorder[i]));
+		z = lround(creal(reorder[i + n]));
+		t = lround(creal(reorder[i + 2 * n]));
 		mask[(y + z * sy) + t * sy * sz] = 1;
 	}
 }
@@ -190,9 +190,9 @@ static void kern_apply(const linop_data_t* _data, complex float* dst, const comp
 
 	for (int i = 0; i < n; i ++) {
 
-		y = data->reorder[i];
-		z = data->reorder[i + n];
-		t = data->reorder[i + 2 * n];
+		y = lround(creal(data->reorder[i]));
+		z = lround(creal(data->reorder[i + n]));
+		t = lround(creal(data->reorder[i + 2 * n]));
 
 		md_clear(4, vec_dims, vec, CFL_SIZE);
 		md_zfmac2(4, fmac_dims, vec_str, vec, phi_in_str, (perm + ((wx * nc * tk) * (y + z * sy))), phi_mat_str, data->phi);
@@ -250,8 +250,8 @@ static void kern_adjoint(const linop_data_t* _data, complex float* dst, const co
 			md_clear(4, vec_dims, vec, CFL_SIZE);
 
 			for (int i = 0; i < n; i ++) {
-				if ((y == data->reorder[i]) && (z == data->reorder[i + n])) {
-					t = data->reorder[i + 2 * n];
+				if ((y == lround(creal(data->reorder[i]))) && (z == lround(creal(data->reorder[i + n])))) {
+					t = lround(creal(data->reorder[i + 2 * n]));
 					md_copy(4, line_dims, (vec + t * wx * nc), (src + i * wx * nc), CFL_SIZE);
 				}
 			}
@@ -536,8 +536,8 @@ static void fftmod_apply(long sy, long sz,
 
 	long n = reorder_dims[0];
 	for (long k = 0; k < n; k++) {
-		y = reorder[k];
-		z = reorder[k + n];
+		y = lround(creal(reorder[k]));
+		z = lround(creal(reorder[k + n]));
 
 		py = cexp(2.i * M_PI * dy * y);
 		pz = cexp(2.i * M_PI * dz * z);

--- a/tests/poly.mk
+++ b/tests/poly.mk
@@ -1,0 +1,9 @@
+tests/test-poly: ones poly nrmse
+	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP) ;\
+	$(TOOLDIR)/ones 1 128 ones.ra                ;\
+	$(TOOLDIR)/poly 128 0 1 poly.ra              ;\
+	$(TOOLDIR)/nrmse -t 0. ones.ra poly.ra       ;\
+	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
+	touch $@
+
+TESTS += tests/test-poly

--- a/tests/wshfl.mk
+++ b/tests/wshfl.mk
@@ -1,0 +1,21 @@
+tests/test-wshfl: wavepsf fft resize transpose squeeze poly join wshfl nrmse $(TESTS_OUT)/shepplogan.ra $(TESTS_OUT)/shepplogan_coil_ksp.ra $(TESTS_OUT)/coils.ra
+	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)                          ;\
+	$(TOOLDIR)/wavepsf -x 640 -y 128 wave_psf.ra                          ;\
+	$(TOOLDIR)/fft -iu 7 $(TESTS_OUT)/shepplogan_coil_ksp.ra img.ra       ;\
+	$(TOOLDIR)/resize -c 0 640 img.ra wave_zpad.ra                        ;\
+	$(TOOLDIR)/fft -u 1 wave_zpad.ra wave_hyb.ra                          ;\
+	$(TOOLDIR)/fmac wave_hyb.ra wave_psf.ra wave_acq.ra                   ;\
+	$(TOOLDIR)/fft -u 6 wave_acq.ra wave_ksp.ra                           ;\
+	$(TOOLDIR)/transpose 1 3 wave_ksp.ra permuted.ra                      ;\
+	$(TOOLDIR)/squeeze permuted.ra table.ra                               ;\
+	$(TOOLDIR)/poly 128 1 0 1 ky.ra                                       ;\
+	$(TOOLDIR)/poly 128 1 0 0 kz.ra                                       ;\
+	$(TOOLDIR)/poly 128 1 0 0 te.ra                                       ;\
+	$(TOOLDIR)/join 1 ky.ra kz.ra te.ra reorder.ra                        ;\
+	$(TOOLDIR)/poly 1 0 1 phi.ra                                          ;\
+	$(TOOLDIR)/wshfl -i 100 $(TESTS_OUT)/coils.ra wave_psf.ra phi.ra reorder.ra table.ra reco.ra ;\
+	$(TOOLDIR)/nrmse -t 0.23 -s reco.ra $(TESTS_OUT)/shepplogan.ra        ;\
+	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
+	touch $@
+
+TESTS += tests/test-wshfl


### PR DESCRIPTION
Wave-shuffling updates:
- Applies ```fftmod``` onto data table to avoid using ```fftc``` in ```linops```.
- Reconstruction now uses ```iter2``` to be consistent with ```pics```.
- Formatting changes.
- Remove the GPU option.

Added ```poly``` command:
- Convenience command like ```zeroes``` and ```ones``` to generate arrays with simple patterns like [0, 1, 2, ... L-1].
- Test added as well.

Added ```test-wshfl``` for ```make test```.

