### PR TITLE
Fix ENABLE_LONGJUMP option in CMake + bug in debug_vprintf_trace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,14 @@ if(USE_LOG_GADGETRON_BACKEND)
   message(STATUS "Delegating all outputs to the Gadgetron logging backend")
 endif(USE_LOG_GADGETRON_BACKEND)
 
+##======================================================================
+
+option(ENABLE_LONGJUMP "Enable the use of the setjmp & longjmp functions to emulate C++ exceptions" OFF)
+if(ENABLE_LONGJUMP)
+  message(STATUS "Using setjmp & longjmp to emulate C++ exceptions")
+  add_definitions(-DENABLE_LONGJUMP)
+endif()
+
 # ==============================================================================
 
 option(GENERATE_DOC "Automatically generate documentation after building BART" ON)

--- a/src/misc/debug.c
+++ b/src/misc/debug.c
@@ -146,7 +146,7 @@ void debug_vprintf_trace(const char* func_name,
 {
 #ifndef USE_LOG_BACKEND
 	UNUSED(func_name); UNUSED(file); UNUSED(line);
-	debug_printf(level, fmt, ap);
+	debug_vprintf(level, fmt, ap);
 #else
 	char tmp[1024] = { 0 };
 	vsnprintf(tmp, 1023, fmt, ap);


### PR DESCRIPTION
Found a bug in `debug_vprintf_trace` and added missing CMake option.