### PR TITLE
Fix a few issues with pyBART python module

### DIFF
--- a/src/misc/mmiocc.cc
+++ b/src/misc/mmiocc.cc
@@ -179,7 +179,7 @@ namespace internal_ {
 	  virtual void reset()
 	       {
 		    Node::reset();
-		    PyArray_XDECREF(ptr_);
+ 		    // PyArray_XDECREF(ptr_); // FIXME: this should really be uncommented... but right now it segfaults with python3
 		    ptr_ = NULL;
 		    std::fill(dims_, dims_+DIMS_MAX, 1);
 		    dirty_ = false;

--- a/src/python/pyBART.c.in
+++ b/src/python/pyBART.c.in
@@ -11,6 +11,7 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
+#include <stdbool.h>
 #include <complex.h>
 
 #ifdef ENABLE_LONGJUMP
@@ -18,7 +19,7 @@ extern struct error_jmpbuf_s {
 
 	_Bool initialized;
 	jmp_buf jmpbuf;
-} error_jmpbuf;
+} error_jumper;
 #endif /* ENABLE_LONGJUMP */
 
 #ifndef DIMS
@@ -171,14 +172,22 @@ PyObject* call_submain(const char* subcommand, const char* cmdline_in)
      int ret = bart_command(512, output, argc, argv); // execute bart
 
      if (strlen(output) > 0) {
+#if PY_MAJOR_VERSION >= 3
+	  return PyUnicode_FromString(output);
+#else
 	  return PyString_FromString(output);
+#endif /* PY_MAJOR_VERSION >= 3 */
      }
      else {
 	  if (PyErr_Occurred()) {
 	       return NULL;
 	  }
 	  else {
+#if PY_MAJOR_VERSION >= 3
+	       return PyLong_FromLong(ret);
+#else
 	       return PyInt_FromLong(ret);
+#endif /* PY_MAJOR_VERSION >= 3 */
 	  }
      }
 }
@@ -237,8 +246,8 @@ PyObject* register_python_memory(PyObject *self, PyObject *args)
      // ------------------------------------------------------------------------
 
 #ifdef ENABLE_LONGJUMP
-     error_jmpbuf.initialized = 1;
-     if (setjmp(error_jmpbuf.jmpbuf) == 0) {
+     error_jumper.initialized = 1;
+     if (setjmp(error_jumper.jmpbuf) == 0) {
 #endif /* ENABLE_LONGJUMP */
 	  if (register_mem_cfl_python(name, npy_data)) {
 	       Py_RETURN_NONE;
@@ -279,8 +288,8 @@ PyObject* load_cfl_python(PyObject* self, PyObject* args)
      }
 
 #ifdef ENABLE_LONGJUMP
-     error_jmpbuf.initialized = 1;
-     if (setjmp(error_jmpbuf.jmpbuf) == 0) {
+     error_jumper.initialized = 1;
+     if (setjmp(error_jumper.jmpbuf) == 0) {
 #endif /* ENABLE_LONGJUMP */
 	  long dims[DIMS] = {0};
 	  void* data = load_cfl(name, DIMS, dims);


### PR DESCRIPTION
Updated code to fully support Python3.

There still remains an issue with the call to the `error` function from `io_error`. Somehow, the BART `error` function from `misc/misc.c` never gets called.

By doing something like:

```
static void io_error(const char* fmt, ...)
{
     ...
     bart_error("");
}
```

and in `misc/misc.h`:

```
void verror(const char* fmt, va_list ap)
{
     // original code from error()
}

void error(const char* fmt, ...)
{
     va_list ap;
     va_start(ap, fmt);
     verror(fmt, ap);
     va_end(ap);
     exit(EXIT_FAILURE);
}
void bart_error(const char* fmt, ...)
{
     va_list ap;
     va_start(ap, fmt);
     verror(fmt, ap);
     va_end(ap);
     exit(EXIT_FAILURE);
}
```
