### PR TITLE
CMake: fix automatic detection of BLAS vendor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,11 +267,13 @@ endif()
 
 ##==============================================================
 
-macro(setup_linalg_vendor vendor target)
-  set(LINALG_VENDOR_LIB ${ARGN})
-  set(LINALG_VENDOR_FOUND TRUE)
-  set(LINALG_VENDOR ${vendor} CACHE STRING "Vendor type for linear algebra library" FORCE)
-  set(LINALG_VENDOR_TGT ${target})
+macro(setup_linalg_vendor_on_success vendor target)
+  if(${target}_FOUND)
+    set(LINALG_VENDOR_LIB ${ARGN})
+    set(LINALG_VENDOR_FOUND TRUE)
+    set(LINALG_VENDOR ${vendor} CACHE STRING "Vendor type for linear algebra library" FORCE)
+    set(LINALG_VENDOR_TGT ${target})
+  endif()
 endmacro()
 
 ##==============================================================
@@ -280,38 +282,48 @@ endmacro()
 ## will be used 
 ##
 ## -*-*- Try with only a BLAS library first if BART_NO_LAPACKE is set
+
+if(NOT "${LINALG_VENDOR}" STREQUAL "")
+  # If the user specifies LINALG_VENDOR, make sure we find what he wants
+  set(FIND_PACKAGE_ARG "REQUIRED")
+else()
+  set(FIND_PACKAGE_ARG)
+endif()
+
 if(BART_NO_LAPACKE AND (NOT LINALG_VENDOR OR LINALG_VENDOR STREQUAL "BLAS"))
-  find_package(LAPACKE REQUIRED COMPONENTS lapack cblas blas)
-  setup_linalg_vendor("BLAS" LAPACKE LAPACKE::LAPACK LAPACKE::CBLAS LAPACKE::BLAS)
+  find_package(LAPACKE ${FIND_PACKAGE_ARG} COMPONENTS lapack cblas blas)
+  setup_linalg_vendor_on_success("BLAS" LAPACKE LAPACKE::LAPACK LAPACKE::CBLAS LAPACKE::BLAS)
 endif()
 
 ## -*-*- Try AMD BLIS/libFlame next
 if(NOT LINALG_VENDOR OR LINALG_VENDOR MATCHES "AMD_FLAME")
-  find_package(libFlame REQUIRED)
-  setup_linalg_vendor("AMD_FLAME" libFlame libFlame::libFlame)
+  find_package(libFlame ${FIND_PACKAGE_ARG})
+  setup_linalg_vendor_on_success("AMD_FLAME" libFlame libFlame::libFlame)
 
-  if(NOT BART_NO_LAPACKE)
-    find_package(LAPACKE REQUIRED COMPONENTS LAPACKE)
-    get_target_property(
-      libFlame_INTERFACE_LINK_LIBRARIES
-      ${LINALG_VENDOR_LIB}
-      INTERFACE_LINK_LIBRARIES)
-    set_target_properties(${LINALG_VENDOR_LIB} PROPERTIES
-      INTERFACE_LINK_LIBRARIES "${libFlame_INTERFACE_LINK_LIBRARIES};LAPACKE::LAPACKE")
+  if(libFlame_FOUND)
+    if(NOT BART_NO_LAPACKE)
+      find_package(LAPACKE REQUIRED COMPONENTS LAPACKE)
+      get_target_property(
+	libFlame_INTERFACE_LINK_LIBRARIES
+	${LINALG_VENDOR_LIB}
+	INTERFACE_LINK_LIBRARIES)
+      set_target_properties(${LINALG_VENDOR_LIB} PROPERTIES
+	INTERFACE_LINK_LIBRARIES "${libFlame_INTERFACE_LINK_LIBRARIES};LAPACKE::LAPACKE")
+    endif()
   endif()
 endif()
 
 ## -*-*- Try OpenBLAS next
 if(NOT LINALG_VENDOR OR LINALG_VENDOR MATCHES "OpenBLAS")
-  find_package(OpenBLAS REQUIRED)
-  setup_linalg_vendor("OpenBLAS" OpenBLAS OpenBLAS::OpenBLAS)
+  find_package(OpenBLAS ${FIND_PACKAGE_ARG})
+  setup_linalg_vendor_on_success("OpenBLAS" OpenBLAS OpenBLAS::OpenBLAS)
 endif()
 
 ##
 ## -*-*- Try ATLAS version next
 if(NOT LINALG_VENDOR OR LINALG_VENDOR MATCHES "ATLAS")
-  find_package(ATLAS REQUIRED)
-  setup_linalg_vendor("ATLAS" ATLAS ATLAS::ATLAS)
+  find_package(ATLAS ${FIND_PACKAGE_ARG})
+  setup_linalg_vendor_on_success("ATLAS" ATLAS ATLAS::ATLAS)
 endif()
 
 ##
@@ -324,8 +336,8 @@ if(NOT LINALG_VENDOR OR LINALG_VENDOR MATCHES "LAPACKE")
   ## for cblas and lapacke.  This method is not very robust to older
   ## versions of lapack that might be able to be supported.
   ## It is know to work local builds
-  find_package(LAPACKE REQUIRED)
-  setup_linalg_vendor("LAPACKE" LAPACKE LAPACKE::LAPACKE LAPACKE::LAPACKE LAPACKE::CBLAS LAPACKE::BLAS)
+  find_package(LAPACKE ${FIND_PACKAGE_ARG})
+  setup_linalg_vendor_on_success("LAPACKE" LAPACKE LAPACKE::LAPACKE LAPACKE::LAPACKE LAPACKE::CBLAS LAPACKE::BLAS)
 endif()
 
 # Fix weird error when compiling on Mac...

--- a/cmake/FindATLAS.cmake
+++ b/cmake/FindATLAS.cmake
@@ -190,18 +190,32 @@ if (ATLAS_FOUND)
     set(MATH_LIB m)
   endif()
   
-  list(APPEND ATLAS_LIBRARIES ${LAPACKE_LIBRARIES}} ${LAPACK_LIB} ${F77BLAS_LIB} ${CBLAS_LIB} ${ATLAS_LIB} ${MATH_LIB})
-endif()
-
-# ==============================================================================
-
-if(NOT TARGET ATLAS::ATLAS)
-  add_library(ATLAS::ATLAS UNKNOWN IMPORTED)
-  set_target_properties(ATLAS::ATLAS
-    PROPERTIES
-    IMPORTED_LOCATION "${ATLAS_LIB}"
-    INTERFACE_INCLUDE_DIRECTORIES "${ATLAS_INCLUDE_DIRS}"
-    INTERFACE_LINK_LIBRARIES "${LAPACKE_LIBRARIES};${LAPACK_LIB};${F77BLAS_LIB};${CBLAS_LIB};${MATH_LIB}")
+  list(APPEND ATLAS_LIBRARIES ${LAPACKE_LIBRARIES} ${LAPACK_LIB} ${F77BLAS_LIB} ${CBLAS_LIB} ${ATLAS_LIB} ${MATH_LIB})
+  
+  if(NOT TARGET ATLAS::ATLAS)
+    get_filename_component(LIB_EXT "${ATLAS_LIB}" EXT)
+    if(LIB_EXT STREQUAL ".a" OR LIB_EXT STREQUAL ".lib")
+      set(LIB_TYPE STATIC)
+    else()
+      set(LIB_TYPE SHARED)
+    endif()
+    add_library(ATLAS::ATLAS ${LIB_TYPE} IMPORTED GLOBAL)
+    set_target_properties(ATLAS::ATLAS
+      PROPERTIES
+      IMPORTED_LOCATION "${ATLAS_LIB}"
+      INTERFACE_INCLUDE_DIRECTORIES "${ATLAS_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${LAPACKE_LIBRARIES};${LAPACK_LIB};${F77BLAS_LIB};${CBLAS_LIB};${MATH_LIB}")
+  endif()
+  
+  if(NOT ATLAS_FIND_QUIETLY)
+    message(STATUS "ATLAS_FOUND           :${ATLAS_FOUND}:  - set to true if the library is found")
+    message(STATUS "ATLAS_INCLUDE_DIRS    :${ATLAS_INCLUDE_DIRS}: - list of required include directories")
+    message(STATUS "ATLAS_LIBRARIES       :${ATLAS_LIBRARIES}: - list of libraries to be linked")
+    message(STATUS "ATLAS_VERSION_MAJOR   :${ATLAS_VERSION_MAJOR}: - major version number")
+    message(STATUS "ATLAS_VERSION_MINOR   :${ATLAS_VERSION_MINOR}: - minor version number")
+    message(STATUS "ATLAS_VERSION_PATCH   :${ATLAS_VERSION_PATCH}: - patch version number")
+    message(STATUS "ATLAS_VERSION_STRING  :${ATLAS_VERSION_STRING}: - version number as a string")
+  endif()
 endif()
 
 # ==============================================================================
@@ -214,14 +228,7 @@ mark_as_advanced(
   ATLAS_VERSION_MINOR
   ATLAS_VERSION_PATCH
   ATLAS_VERSION_STRING
-)
+  )
 
-if(NOT ATLAS_FIND_QUIETLY)
-  message(STATUS "ATLAS_FOUND           :${ATLAS_FOUND}:  - set to true if the library is found")
-  message(STATUS "ATLAS_INCLUDE_DIRS    :${ATLAS_INCLUDE_DIRS}: - list of required include directories")
-  message(STATUS "ATLAS_LIBRARIES       :${ATLAS_LIBRARIES}: - list of libraries to be linked")
-  message(STATUS "ATLAS_VERSION_MAJOR   :${ATLAS_VERSION_MAJOR}: - major version number")
-  message(STATUS "ATLAS_VERSION_MINOR   :${ATLAS_VERSION_MINOR}: - minor version number")
-  message(STATUS "ATLAS_VERSION_PATCH   :${ATLAS_VERSION_PATCH}: - patch version number")
-  message(STATUS "ATLAS_VERSION_STRING  :${ATLAS_VERSION_STRING}: - version number as a string")
-endif()
+# ==============================================================================
+

--- a/cmake/FindLAPACKE.cmake
+++ b/cmake/FindLAPACKE.cmake
@@ -178,34 +178,49 @@ if(LAPACKE_FOUND)
   if(NOT "${LAPACKE_INCLUDE_DIRS}" STREQUAL "")
     list(REMOVE_DUPLICATES LAPACKE_INCLUDE_DIRS)
   endif()
-endif()
 
-# ------------------------------------------------------------------------------
+  # ----------------------------------------------------------------------------
 
-set(LAPACKE_IMPORTED_TARGET_LIST)
-# Inspired by FindBoost.cmake
-foreach(COMPONENT ${LAPACKE_FIND_COMPONENTS})
-  string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
-  if(NOT TARGET LAPACKE::${UPPERCOMPONENT} AND LAPACKE_${UPPERCOMPONENT}_FOUND)
-    add_library(LAPACKE::${UPPERCOMPONENT} UNKNOWN IMPORTED)
-    if(LAPACKE_INCLUDE_DIRS)
+  # Inspired by FindBoost.cmake
+  foreach(COMPONENT ${LAPACKE_FIND_COMPONENTS})
+    string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
+    if(NOT TARGET LAPACKE::${UPPERCOMPONENT} AND LAPACKE_${UPPERCOMPONENT}_FOUND)
+      get_filename_component(LIB_EXT "${LAPACKE_${UPPERCOMPONENT}_LIB}" EXT)
+      if(LIB_EXT STREQUAL ".a" OR LIB_EXT STREQUAL ".lib")
+        set(LIB_TYPE STATIC)
+      else()
+        set(LIB_TYPE SHARED)
+      endif()
+      add_library(LAPACKE::${UPPERCOMPONENT} ${LIB_TYPE} IMPORTED GLOBAL)
+      if(LAPACKE_INCLUDE_DIRS)
+        set_target_properties(LAPACKE::${UPPERCOMPONENT} PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${LAPACKE_INCLUDE_DIRS}")
+      endif()
+      if(EXISTS "${LAPACKE_${UPPERCOMPONENT}_LIB}")
+        set_target_properties(LAPACKE::${UPPERCOMPONENT} PROPERTIES
+          IMPORTED_LOCATION "${LAPACKE_${UPPERCOMPONENT}_LIB}")
+      endif()
       set_target_properties(LAPACKE::${UPPERCOMPONENT} PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${LAPACKE_INCLUDE_DIRS}")
+        INTERFACE_LINK_LIBRARIES "${MATH_LIB}")
     endif()
-    if(EXISTS "${LAPACKE_${UPPERCOMPONENT}_LIB}")
-      set_target_properties(LAPACKE::${UPPERCOMPONENT} PROPERTIES
-        IMPORTED_LOCATION "${LAPACKE_${UPPERCOMPONENT}_LIB}")
-    endif()
-    set_target_properties(LAPACKE::${UPPERCOMPONENT} PROPERTIES
-      INTERFACE_LINK_LIBRARIES "${MATH_LIB}")
-    list(APPEND LAPACKE_IMPORTED_TARGET_LIST LAPACKE::${UPPERCOMPONENT})
+  endforeach()
+
+  # ----------------------------------------------------------------------------
+
+  if(NOT LAPACKE_FIND_QUIETLY)
+    message(STATUS "LAPACKE_FOUND         :${LAPACKE_FOUND}:  - set to true if the library is found")
+    message(STATUS "LAPACKE_INCLUDE_DIRS  :${LAPACKE_INCLUDE_DIRS}: - list of required include directories")
+    message(STATUS "LAPACKE_LIBRARIES     :${LAPACKE_LIBRARIES}: - list of libraries to be linked")
   endif()
-endforeach()
+endif()
 
 # ==============================================================================
 
-if(NOT LAPACKE_FIND_QUIETLY)
-  message(STATUS "LAPACKE_FOUND         :${LAPACKE_FOUND}:  - set to true if the library is found")
-  message(STATUS "LAPACKE_INCLUDE_DIRS  :${LAPACKE_INCLUDE_DIRS}: - list of required include directories")
-  message(STATUS "LAPACKE_LIBRARIES     :${LAPACKE_LIBRARIES}: - list of libraries to be linked")
-endif()
+mark_as_advanced(
+  LAPACKE_FOUND
+  LAPACKE_INCLUDE_DIRS
+  LAPACKE_LIBRARIES
+  )
+
+
+

--- a/cmake/FindOpenBLAS.cmake
+++ b/cmake/FindOpenBLAS.cmake
@@ -187,25 +187,45 @@ if (OpenBLAS_FOUND)
   if(OpenBLAS_HAS_PARALLEL_LIBRARIES)
     list(APPEND OpenBLAS_PARALLEL_LIBRARIES ${OpenBLAS_PARALLEL_LIB})
   endif()
-endif()
 
-# ==============================================================================
+  # ----------------------------------------------------------------------------
 
-if(NOT TARGET OpenBLAS::OpenBLAS)
-  add_library(OpenBLAS::OpenBLAS UNKNOWN IMPORTED)
-  set_target_properties(OpenBLAS::OpenBLAS
-    PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${OpenBLAS_INCLUDE_DIRS}"
-    INTERFACE_LINK_LIBRARIES "${MATH_LIB};${LAPACKE_LIBRARIES}")
-  
-  if(OpenBLAS_HAS_PARALLEL_LIBRARIES)
+  if(NOT TARGET OpenBLAS::OpenBLAS)
+    get_filename_component(LIB_EXT "${LAPACKE_${UPPERCOMPONENT}_LIB}" EXT)
+    if(LIB_EXT STREQUAL ".a" OR LIB_EXT STREQUAL ".lib")
+      set(LIB_TYPE STATIC)
+    else()
+      set(LIB_TYPE SHARED)
+    endif()
+    add_library(OpenBLAS::OpenBLAS ${LIB_TYPE} IMPORTED GLOBAL)
     set_target_properties(OpenBLAS::OpenBLAS
       PROPERTIES
-      IMPORTED_LOCATION "${OpenBLAS_PARALLEL_LIB}")
-  else()
-    set_target_properties(OpenBLAS::OpenBLAS
-      PROPERTIES
-      IMPORTED_LOCATION "${OpenBLAS_LIB}")
+      INTERFACE_INCLUDE_DIRECTORIES "${OpenBLAS_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${MATH_LIB};${LAPACKE_LIBRARIES}")
+    
+    if(OpenBLAS_HAS_PARALLEL_LIBRARIES)
+      set_target_properties(OpenBLAS::OpenBLAS
+	PROPERTIES
+	IMPORTED_LOCATION "${OpenBLAS_PARALLEL_LIB}")
+    else()
+      set_target_properties(OpenBLAS::OpenBLAS
+	PROPERTIES
+	IMPORTED_LOCATION "${OpenBLAS_LIB}")
+    endif()
+  endif()
+
+  # ----------------------------------------------------------------------------
+
+  if(NOT OpenBLAS_FIND_QUIETLY)
+    message(STATUS "OpenBLAS_FOUND                  :${OpenBLAS_FOUND}:  - set to true if the library is found")
+    message(STATUS "OpenBLAS_INCLUDE_DIRS           :${OpenBLAS_INCLUDE_DIRS}: - list of required include directories")
+    message(STATUS "OpenBLAS_LIBRARIES              :${OpenBLAS_LIBRARIES}: - list of libraries to be linked")
+    message(STATUS "OpenBLAS_HAS_PARALLEL_LIBRARIES :${OpenBLAS_HAS_PARALLEL_LIBRARIES}: - determine if there are parallel libraries compiled")
+    message(STATUS "OpenBLAS_PARALLEL_LIBRARIES     :${OpenBLAS_PARALLEL_LIBRARIES}: - list of libraries for parallel implementations")
+    message(STATUS "OpenBLAS_VERSION_MAJOR          :${OpenBLAS_VERSION_MAJOR}: - major version number")
+    message(STATUS "OpenBLAS_VERSION_MINOR          :${OpenBLAS_VERSION_MINOR}: - minor version number")
+    message(STATUS "OpenBLAS_VERSION_PATCH          :${OpenBLAS_VERSION_PATCH}: - patch version number")
+    message(STATUS "OpenBLAS_VERSION_STRING         :${OpenBLAS_VERSION_STRING}: - version number as a string")
   endif()
 endif()
 
@@ -221,16 +241,5 @@ mark_as_advanced(
   OpenBLAS_VERSION_MINOR
   OpenBLAS_VERSION_PATCH
   OpenBLAS_VERSION_STRING
-)
+  )
 
-if(NOT OpenBLAS_FIND_QUIETLY)
-  message(STATUS "OpenBLAS_FOUND                  :${OpenBLAS_FOUND}:  - set to true if the library is found")
-  message(STATUS "OpenBLAS_INCLUDE_DIRS           :${OpenBLAS_INCLUDE_DIRS}: - list of required include directories")
-  message(STATUS "OpenBLAS_LIBRARIES              :${OpenBLAS_LIBRARIES}: - list of libraries to be linked")
-  message(STATUS "OpenBLAS_HAS_PARALLEL_LIBRARIES :${OpenBLAS_HAS_PARALLEL_LIBRARIES}: - determine if there are parallel libraries compiled")
-  message(STATUS "OpenBLAS_PARALLEL_LIBRARIES     :${OpenBLAS_PARALLEL_LIBRARIES}: - list of libraries for parallel implementations")
-  message(STATUS "OpenBLAS_VERSION_MAJOR          :${OpenBLAS_VERSION_MAJOR}: - major version number")
-  message(STATUS "OpenBLAS_VERSION_MINOR          :${OpenBLAS_VERSION_MINOR}: - minor version number")
-  message(STATUS "OpenBLAS_VERSION_PATCH          :${OpenBLAS_VERSION_PATCH}: - patch version number")
-  message(STATUS "OpenBLAS_VERSION_STRING         :${OpenBLAS_VERSION_STRING}: - version number as a string")
-endif()


### PR DESCRIPTION
It appears the last changes I made with #141 broke the automatic BLAS vendor detection when using CMake (ie. when no LINALG_VENDOR variable is provided to CMake).

This PR fixes that.