### PR TITLE
fix various memory leaks

### DIFF
--- a/src/iter/admm.c
+++ b/src/iter/admm.c
@@ -521,6 +521,13 @@ void admm(const struct admm_plan_s* plan,
 	vops->del(rhs);
 	vops->del(s);
 
+	for (unsigned int j = 0; j < num_funs; j++) {
+
+		vops->del(z[j]);
+		vops->del(u[j]);
+		vops->del(r[j]);
+	}
+
 	if (!plan->fast)
 		vops->del(GH_usum);
 }

--- a/src/iter/lsqr.c
+++ b/src/iter/lsqr.c
@@ -210,6 +210,7 @@ const struct operator_s* wlsqr2_create(	const struct lsqr_conf* conf,
 					struct iter_monitor_s* monitor)
 {
 	struct linop_s* op = linop_chain(model_op, weights);
+	linop_free(model_op);
 
 	const struct operator_s* lsqr_op = lsqr2_create(conf, italgo, iconf, init,
 						op, precond_op,
@@ -218,6 +219,7 @@ const struct operator_s* wlsqr2_create(	const struct lsqr_conf* conf,
 
 	const struct operator_s* wlsqr_op = operator_chain(weights->forward, lsqr_op);
 
+	linop_free(weights);
 	operator_free(lsqr_op);
 	linop_free(op);
 

--- a/src/pics.c
+++ b/src/pics.c
@@ -69,7 +69,9 @@ static const struct linop_s* sense_nc_init(const long max_dims[DIMS], const long
 		 */
 
 		const struct linop_s* fft_slice = linop_fft_create(DIMS, map_dims, SLICE_FLAG);
-		fft_op = linop_chain(fft_slice, fft_op);
+		const struct linop_s* tmp = fft_op;
+		fft_op = linop_chain(fft_slice, tmp);
+		linop_free(tmp);
 		linop_free(fft_slice);
 	}
 
@@ -451,6 +453,7 @@ int main_pics(int argc, char* argv[])
 
 	if ((NULL == traj_file) && !sms) {
 
+		linop_free(forward_op);
 		forward_op = sense_init(max1_dims, map_flags, maps);
 
 		// basis pursuit requires the full forward model to add as a linop constraint

--- a/src/sense/recon.c
+++ b/src/sense/recon.c
@@ -168,6 +168,8 @@ const struct operator_s* sense_recon_create(const struct sense_conf* conf, const
 
 		op = lad2_create(&lad_conf, italgo, iconf, (const float*)init, sense_op, num_funs, thresh_op, thresh_funs);
 
+		linop_free(sense_op);
+
 	} else
 	if (NULL == pattern) {
 
@@ -177,6 +179,8 @@ const struct operator_s* sense_recon_create(const struct sense_conf* conf, const
 		else
 			op = lsqr2_create(&lsqr_conf, italgo, iconf, (const float*)init, sense_op, precond_op,
 					num_funs, thresh_op, thresh_funs, NULL);
+
+		linop_free(sense_op);
 
 	} else {
 


### PR DESCRIPTION
The only remaining on that I could find is in `sense_recon_create()` (see here: https://github.com/mrirecon/bart/blob/53923792f2cda9e1ef4be7ef51d299a2ce02a10b/src/sense/recon.c#L185).

The weights array allocated here is never freed, since `linop_cdiag_create()` does not copy. Therefore, we'd need to keep the array pointer around, but I have not found a good way to do that.