### PR TITLE
 CMake: update CUDA detection and update FindFFTW.cmake + minor updates to mmiocc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,23 @@ enable_language(C)
 if(CMAKE_VERSION VERSION_GREATER 3.0)
   cmake_policy(SET CMP0051 NEW)
   cmake_policy(SET CMP0057 NEW) # if IN_LIST
+  cmake_policy(SET CMP0028 NEW) # :: in target names
+  if(CMAKE_VERSION VERSION_LESS 3.8) # 3.8 instead of 3.3 due to CUDA support
+    cmake_policy(SET CMP0023 OLD) # target_link_libraries mixed signatures
+  else()
+    cmake_policy(SET CMP0023 NEW) # target_link_libraries mixed signatures
+  endif()
 endif(CMAKE_VERSION VERSION_GREATER 3.0)
+
+list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_LIST_DIR}/cmake)
+
+#==============================================================================
+# Options
+
+# NB: must be before compiler flags since we might enable CXX or CUDA
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/bart_options.cmake)
+
+#==============================================================================
 
 # http://stackoverflow.com/questions/24840030/forcing-c99-in-cmake-to-use-for-loop-initial-declaration
 if (CMAKE_VERSION VERSION_LESS "3.1")
@@ -21,8 +37,15 @@ if (CMAKE_VERSION VERSION_LESS "3.1")
       CMAKE_C_COMPILER_ID STREQUAL "Clang")
     set (CMAKE_C_FLAGS "--std=gnu11 ${CMAKE_C_FLAGS}")
   endif()
+  if (CMAKE_CX_COMPILER_ID STREQUAL "GNU" OR
+      CMAKE_CX_COMPILER_ID STREQUAL "Clang")
+    set (CMAKE_CXX_FLAGS "--std=c++11x ${CMAKE_CXX_FLAGS}")
+  endif()
 else()
   set (CMAKE_C_STANDARD 11)
+  set (CMAKE_C_STANDARD_REQUIRED ON)
+  set (CMAKE_CXX_STANDARD 11)
+  set (CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
 set(CMAKE_DEBUG_POSTFIX "d")
@@ -35,17 +58,9 @@ if ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang"
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fblocks")
 endif()
 
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake ${CMAKE_MODULE_PATH})
-
-#==============================================================================
-# Options
-
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/bart_options.cmake)
-
 # ==============================================================================
 
 # --- Provide good defaults for searching for packages (i.e. ismrmrd)
-set(CMAKE_PREFIX_PATH)
 if(NOT CMAKE_PREFIX_PATH)
   list(APPEND CMAKE_PREFIX_PATH "/usr/local")
 endif()
@@ -80,12 +95,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
   # Set the possible values of build type for cmake-gui
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "RelWithDebInfo")
-endif()
-
-find_package(ISMRMRD QUIET) ## if you can find ISMRMRD by default, then default configuration is ON
-option(BART_ISMRMRD "Use external ISMRMRD package for reading/writing" ${ISMRMRD_FOUND})
-if(BART_ISMRMRD)
-  find_package(ISMRMRD REQUIRED)
 endif()
 
 ## Compiler flags -- TODO This could be better, see ITK it won't work on windows builds
@@ -195,22 +204,33 @@ macro(CONFIG_BY_REPLACEMENT INFILE OUTFILE PREFIX )
   endif()
 endmacro()
 
-set(BART_SUPPORT_LIBS calib misc dfwavelet grecon iter linops lowrank nlops noir noncart num sake sense simu wavelet)
+set(BART_SUPPORT_LIBS)
+file(GLOB support_libs ${CMAKE_CURRENT_LIST_DIR}/src/*)
+foreach(_f ${support_libs})
+  if(IS_DIRECTORY ${_f})
+    get_filename_component(_name ${_f} NAME)
+    if(NOT "${_name}" STREQUAL "python")
+      list(APPEND BART_SUPPORT_LIBS ${_name})
+    endif()
+  endif()
+endforeach()
+
 if(BART_ISMRMRD)
-  list(APPEND BART_SUPPORT_LIBS ismrm)
   link_directories(${ISMRMRD_LIBRARY_DIRS})
   include_directories(${ISMRMRD_INCLUDE_DIRS})
+else()
+    list(REMOVE_ITEM BART_SUPPORT_LIBS ismrm)
 endif()
 
-if(BART_NO_LAPACKE)
-  list(APPEND BART_SUPPORT_LIBS lapacke)
-endif(BART_NO_LAPACKE)
+if(NOT BART_NO_LAPACKE)
+  list(REMOVE_ITEM BART_SUPPORT_LIBS lapacke)
+endif()
 
 include_directories(${CMAKE_CURRENT_LIST_DIR}/src)
 
 set(bart_support_SRCS "")
 set(bart_support_CCSRCS "")
-set(bart_support_CUSRCS "" CACHE INTERNAL "")
+set(bart_support_CUSRCS "")
 foreach(curr_lib ${BART_SUPPORT_LIBS})
     file(GLOB ${curr_lib}_SRCS "src/${curr_lib}/*.c")
     list(APPEND bart_support_SRCS ${${curr_lib}_SRCS})
@@ -218,10 +238,8 @@ foreach(curr_lib ${BART_SUPPORT_LIBS})
     file(GLOB ${curr_lib}_CCSRCS "src/${curr_lib}/*.cc")
     list(APPEND bart_support_SRCS ${${curr_lib}_CCSRCS})
 
-    if(USE_CUDA)
-      file(GLOB ${curr_lib}_CUSRCS "src/${curr_lib}/*.cu")
-      list(APPEND bart_support_CUSRCS ${${curr_lib}_CUSRCS})
-    endif(USE_CUDA)
+    file(GLOB ${curr_lib}_CUSRCS "src/${curr_lib}/*.cu")
+    list(APPEND bart_support_CUSRCS ${${curr_lib}_CUSRCS})
 endforeach()
 
 # ------------------------------------------------------------------------------
@@ -231,7 +249,7 @@ endforeach()
 set(BARTSUPPORT_PYTHON_SEPARATE_COMPILATION_FILES
   "${CMAKE_CURRENT_LIST_DIR}/src/misc/mmiocc.cc"
   "${CMAKE_CURRENT_LIST_DIR}/src/misc/mmio.c"
-  "${CMAKE_CURRENT_LIST_DIR}/src/misc/misc.c" CACHE INTERNAL "")
+  "${CMAKE_CURRENT_LIST_DIR}/src/misc/misc.c")
 foreach(file ${BARTSUPPORT_PYTHON_SEPARATE_COMPILATION_FILES})
   list(REMOVE_ITEM bart_support_SRCS "${file}")
 endforeach()
@@ -286,7 +304,7 @@ if(BART_LOG_BACKEND)
     include (${TOPDIR}/recon/SDK/product.cmake)
 
     # FIXME: need to check which libraries are actually required
-    target_link_libraries(bartsupport Core Common Control System ${OX_3P_LIBS} ${OX_OS_LIBS})
+    target_link_libraries(bartsupport PUBLIC "Core;Common;Control;System;${OX_3P_LIBS};${OX_OS_LIBS}")
     
     list(APPEND LOG_BACKEND_SRCS "${CMAKE_CURRENT_LIST_DIR}/src/misc/Orchestra.cc")
   endif(BART_LOG_ORCHESTRA_BACKEND)
@@ -298,21 +316,22 @@ if(BART_LOG_BACKEND)
   endif(BART_LOG_GADGETRON_BACKEND)
 endif(BART_LOG_BACKEND)
 
-set(LOG_BACKEND_SRCS "${LOG_BACKEND_SRCS}" CACHE INTERNAL "")
 foreach(file ${LOG_BACKEND_SRCS})
   list(REMOVE_ITEM bart_support_SRCS "${file}")
 endforeach()
 
 if(USE_CUDA)
-  cuda_wrap_srcs(bartsupport_objs OBJ bartsupport_cuda_objs ${bart_support_CUSRCS})
-else()
-  set(bart_support_CUDA "")
+  if("${CMAKE_VERSION}" VERSION_GREATER_EQUAL 3.8)
+    set(bartsupport_cuda_objs ${bart_support_CUSRCS})
+  else()
+    cuda_wrap_srcs(bartsupport_objs OBJ bartsupport_cuda_objs ${bart_support_CUSRCS})
+  endif()
 endif(USE_CUDA)
 
-add_library(bartsupport_objs OBJECT ${bart_support_SRCS})
+bart_add_object_library(bartsupport_objs ${bart_support_SRCS})
 bart_add_library(bartsupport STATIC $<TARGET_OBJECTS:bartsupport_objs> ${DEBUG_C_FILE} ${BARTSUPPORT_PYTHON_SEPARATE_COMPILATION_FILES} ${bartsupport_cuda_objs})
 
-target_link_libraries(bartsupport PUBLIC ${LINALG_VENDOR_LIB} ${PNG_LIBRARIES} ${FFTWF_LIBRARIES})
+target_link_libraries(bartsupport PUBLIC "${LINALG_VENDOR_LIB};${PNG_TGT};${FFTW_TGT}")
 if(BART_ISMRMRD)
   target_link_libraries(bartsupport PUBLIC ${ISMRMRD_LIBRARIES})
 endif()
@@ -326,6 +345,7 @@ set_target_properties(bartsupport
 
 ## Generate combined programs
 #==============================================
+
 set(EXTERN_LIST "\n\n/* Generated by cmake */\n")
 foreach(driver ${ALLPROGS})
    set(EXTERN_LIST "${EXTERN_LIST}extern int main_${driver}(int argc, char* argv[])__EOL__\n")
@@ -339,6 +359,7 @@ CONFIG_BY_REPLACEMENT( "${CMAKE_CURRENT_LIST_DIR}/src/main.h" "${CMAKE_CURRENT_B
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/CombinedCode)
 
 #==============================================
+
 set(DRIVER_LIST "\n\n/* Generated by cmake */\n")
 foreach(driver ${ALLPROGS})
    set(DRIVER_LIST "${DRIVER_LIST}{ main_${driver}, \"${driver}\" },\n")
@@ -375,12 +396,14 @@ target_link_libraries(bart PRIVATE bartsupport)
 set_target_properties(bart PROPERTIES EXPORT_NAME BART)
 
 set(BARTMAIN_PYTHON_SEPARATE_COMPILATION_FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/CombinedCode/bart_lib.c" CACHE INTERNAL "")
+  "${CMAKE_CURRENT_BINARY_DIR}/CombinedCode/bart_lib.c")
 foreach(file ${BARTMAIN_PYTHON_SEPARATE_COMPILATION_FILES})
   list(REMOVE_ITEM ALL_BART_LIB_SRCS "${file}")
 endforeach()
       
-add_library(bartmain_objs OBJECT ${ALL_BART_LIB_SRCS})
+# ==============================================================================
+
+bart_add_object_library(bartmain_objs ${ALL_BART_LIB_SRCS})
 add_library(bartmain
   STATIC
   $<TARGET_OBJECTS:bartsupport_objs>
@@ -390,7 +413,7 @@ add_library(bartmain
   ${BARTMAIN_PYTHON_SEPARATE_COMPILATION_FILES}
   ${bartsupport_cuda_objs})
 
-target_link_libraries(bartmain PUBLIC ${LINALG_VENDOR_LIB} ${PNG_LIBRARIES} ${FFTWF_LIBRARIES})
+target_link_libraries(bartmain PUBLIC "${LINALG_VENDOR_LIB};${PNG_TGT};${FFTW_TGT}")
 if(BART_ISMRMRD)
   target_link_libraries(bartmain PUBLIC ${ISMRMRD_LIBRARIES})
 endif()
@@ -439,7 +462,6 @@ if(BART_CREATE_PYTHON_MODULE)
 
   configure_file(${CMAKE_CURRENT_LIST_DIR}/src/python/pyBART.c.in ${PROJECT_BINARY_DIR}/pyBART.c @ONLY)
 
-  include_directories(${PYMODULE_INCLUDE_DIRS})
   bart_add_library(pyBART
     SHARED
     ${PROJECT_BINARY_DIR}/pyBART.c
@@ -447,11 +469,12 @@ if(BART_CREATE_PYTHON_MODULE)
     ${BARTMAIN_PYTHON_SEPARATE_COMPILATION_FILES}
     $<TARGET_OBJECTS:bartsupport_objs>
     $<TARGET_OBJECTS:bartmain_objs>)
-  
+
+  target_include_directories(pyBART PRIVATE ${PYMODULE_INCLUDE_DIRS})
   target_compile_definitions(pyBART PRIVATE -DBART_WITH_PYTHON)
-  target_link_libraries(pyBART ${PYMODULE_LIBRARIES} ${PNG_LIBRARIES} ${FFTWF_LIBRARIES} ${LINALG_LIBRARIES})
+  target_link_libraries(pyBART PUBLIC "${PYMODULE_LIBRARIES};${PNG_TGT};${FFTW_TGT};${LINALG_LIBRARIES}")
   if(BART_ISMRMRD)
-    target_link_libraries(pyBART ${ISMRMRD_LIBRARIES})
+    target_link_libraries(pyBART PUBLIC ${ISMRMRD_LIBRARIES})
   endif()
   set_target_properties(pyBART
     PROPERTIES

--- a/cmake/BARTConfig.cmake.in
+++ b/cmake/BARTConfig.cmake.in
@@ -29,9 +29,39 @@ set(LINALG_VENDOR "@LINALG_VENDOR@")
 
 get_filename_component(BART_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
-list(APPEND CMAKE_MODULE_PATH ${BART_CMAKE_DIR})
+list(INSERT CMAKE_MODULE_PATH 0 ${BART_CMAKE_DIR})
+
+include(CMakeFindDependencyMacro)
+
 include(${BART_CMAKE_DIR}/BARTFindBLASlib.cmake)
-list(REMOVE_AT CMAKE_MODULE_PATH -1)
+
+if(BART_ISMRMRD)
+  find_dependency(ISMRMRD)
+endif()
+
+if(NOT BART_LOCAL_FFTW)
+  if(CMAKE_VERSION VERSION_GREATER 3.8)
+    find_dependency(FFTW 3 COMPONENTS FFTWF FFTWF_MT)
+  else()
+    find_package(FFTW 3 REQUIRED COMPONENTS FFTWF FFTWF_MT)
+  endif()
+else()
+  find_dependency(Threads)
+endif()
+
+if(NOT BART_DISABLE_PNG)
+  find_dependency(PNG)
+endif()
+
+if(BART_USE_CUDA AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.8)
+  if(CMAKE_VERSION VERSION_GREATER 3.8)
+    find_dependency(CUDAlibs COMPONENTS CUBLAS CUFFT)
+  else()
+    find_package(CUDAlibs REQUIRED COMPONENTS CUBLAS CUFFT)
+  endif()
+endif()
+
+list(REMOVE_AT CMAKE_MODULE_PATH 0)
 
 # ==============================================================================
 

--- a/cmake/FindCUDAlibs.cmake
+++ b/cmake/FindCUDAlibs.cmake
@@ -1,0 +1,251 @@
+#.rst:
+# FindCUDAlibs
+# -------------
+#
+# Find CUDA include dirs and libraries
+#
+# Use this module by invoking find_package with the form::
+#
+#   find_package(CUDAlibs
+#     [REQUIRED]             # Fail with error if LAPACKE is not found
+#     [COMPONENTS <comp>...] # List of components to look for
+#     )                      # Not specifying any components is equivalent to
+#                              looking for the BASIC libraries
+#
+# Valid names for COMPONENTS libraries are::
+#
+#   ALL         - Find all libraries
+#   BASIC       - Equivalent to CUDART;CUBLAS;CUFFT
+#
+#   CUDART      - CUDA RT library
+#   CUBLAS      - CUDA BLAS library
+#   CUFFT       - CUDA FFT library
+#   CUFFTW      - CUDA FFTW library
+#   CUPTI       - CUDA Profiling Tools Interface library.
+#   CURAND      - CUDA Random Number Generation library.
+#   CUSOLVER    - CUDA Direct Solver library.
+#   CUSPARSE    - CUDA Sparse Matrix library.
+#   NPP         - NVIDIA Performance Primitives lib.
+#   NPPC        - NVIDIA Performance Primitives lib (core).
+#   NPPI        - NVIDIA Performance Primitives lib (image processing).
+#   NPPIAL      - NVIDIA Performance Primitives lib (image processing).
+#   NPPICC      - NVIDIA Performance Primitives lib (image processing).
+#   NPPICOM     - NVIDIA Performance Primitives lib (image processing).
+#   NPPIDEI     - NVIDIA Performance Primitives lib (image processing).
+#   NPPIF       - NVIDIA Performance Primitives lib (image processing).
+#   NPPIG       - NVIDIA Performance Primitives lib (image processing).
+#   NPPIM       - NVIDIA Performance Primitives lib (image processing).
+#   NPPIST      - NVIDIA Performance Primitives lib (image processing).
+#   NPPISU      - NVIDIA Performance Primitives lib (image processing).
+#   NPPITC      - NVIDIA Performance Primitives lib (image processing).
+#   NPPS        - NVIDIA Performance Primitives lib (signal processing).
+#   NVBLAS      - NVIDIA BLAS library
+#
+#  Not specifying COMPONENTS is identical to choosing ALL
+#
+# This module reads hints about search locations from variables
+# (either CMake variables or environment variables)::
+#
+#   CUDA_TOOLKIT_ROOT_DIR
+#   CUDA_PATH
+#   CUDA_LIB_PATH
+#
+# The following :prop_tgt:`IMPORTED` targets are always defined::
+#
+#   CUDAlibs::HEADERS        - Imported target for the CUDA headers
+#
+#
+# The following :prop_tgt:`IMPORTED` targets are defined if required::
+#
+#   CUDAlibs::CUDART         - Imported target for the CUDA RT library
+#   CUDAlibs::CUBLAS         - Imported target for the CUDA cublas library
+#   CUDAlibs::CUFFT          - Imported target for the CUDA cufft library
+#   CUDAlibs::CUFFTW         - Imported target for the CUDA cufftw library
+#   CUDAlibs::CUPTI          - Imported target for the CUDA cupti library
+#   CUDAlibs::CURAND         - Imported target for the CUDA curand library
+#   CUDAlibs::CUSOLVER       - Imported target for the CUDA cusolver library
+#   CUDAlibs::CUSPARSE       - Imported target for the CUDA cusparse library
+#   CUDAlibs::NPP            - Imported target for the CUDA npp library
+#   CUDAlibs::NPPC           - Imported target for the CUDA nppc library
+#   CUDAlibs::NPPI           - Imported target for the CUDA nppi library
+#   CUDAlibs::NPPIAL         - Imported target for the CUDA nppial library
+#   CUDAlibs::NPPICC         - Imported target for the CUDA nppicc library
+#   CUDAlibs::NPPICOM        - Imported target for the CUDA nppicom library
+#   CUDAlibs::NPPIDEI        - Imported target for the CUDA nppidei library
+#   CUDAlibs::NPPIF          - Imported target for the CUDA nppif library
+#   CUDAlibs::NPPIG          - Imported target for the CUDA nppig library
+#   CUDAlibs::NPPIM          - Imported target for the CUDA nppim library
+#   CUDAlibs::NPPIST         - Imported target for the CUDA nppist library
+#   CUDAlibs::NPPISU         - Imported target for the CUDA nppisu library
+#   CUDAlibs::NPPITC         - Imported target for the CUDA nppitc library
+#   CUDAlibs::NPPS           - Imported target for the CUDA npps library
+#   CUDAlibs::NVBLAS         - Imported target for the CUDA nvblas library
+#
+
+# ==============================================================================
+# Copyright 2018 Damien Nguyen <damien.nguyen@alumni.epfl.ch>
+#
+# Distributed under the OSI-approved BSD License (the "License")
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# ==============================================================================
+
+if(CMAKE_VERSION VERSION_LESS 3.8)
+  message(FATAL_ERROR "Cannot use find_package(CUDAlibs ...) with CMake < 3.8! Use find_package(CUDA) instead.")
+endif()
+
+# ------------------------------------------------------------------------------
+
+set(CUDAlibs_SEARCH_PATHS
+  ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}
+  ${CUDA_ROOT}
+  $ENV{CUDA_ROOT}
+  ${CMAKE_PREFIX_PATH}
+  $ENV{CMAKE_PREFIX_PATH}
+  /usr
+  /usr/local
+  /usr/local/cuda
+  /opt
+  /opt/local
+  "C:/Program\ Files/NVIDIA\ GPU\ Computing\ Toolkit/CUDA"
+  )
+
+set(PATH_SUFFIXES_LIST lib/x64 lib64 libx64 lib lib/Win32 lib libWin32)
+
+# ==============================================================================
+# Prepare some helper variables
+
+set(CUDAlibs_REQUIRED_VARS)
+
+# ==============================================================================
+
+macro(cuda_find_library component)
+  string(TOLOWER ${COMPONENT} libnames)
+
+  find_library(CUDAlibs_${component}_LIB
+    NAMES ${libnames}
+    PATHS ${CUDAlibs_SEARCH_PATHS}
+    PATH_SUFFIXES ${PATH_SUFFIXES_LIST}
+    NO_DEFAULT_PATH)
+
+  if(CUDAlibs_${component}_LIB)
+    set(CUDAlibs_${component}_LIB_FOUND 1)
+  endif()
+  list(APPEND CUDAlibs_REQUIRED_VARS "CUDAlibs_${component}_LIB")
+  
+  if(CUDAlibs_${component}_LIB_FOUND)
+    set(CUDAlibs_${component}_FOUND 1)
+  else()
+    set(CUDAlibs_${component}_FOUND 0)
+  endif()
+endmacro()
+
+# ------------------------------------------------------------------------------
+
+set(CUDAlibs_ALL_LIBS "CUDA_H;CUDART;CUBLAS;CUFFT;CUFFTW;CUPTI;CURAND;CUSOLVER;CUSPARSE;NPP;NPPC;NPPI;NPPIAL;NPPICC;NPPICOM;NPPIDEI;NPPIF;NPPIG;NPPIM;NPPIST;NPPISU;NPPITC;NPPS;NVBLAS")
+
+# List dependent libraries for relevant targets
+set(CUDAlibs_DEP_CUFFTW "CUFFT")
+set(CUDAlibs_DEP_NPPIAL "NPPC")
+set(CUDAlibs_DEP_NPPICC "NPPC")
+set(CUDAlibs_DEP_NPPICOM "NPPC")
+set(CUDAlibs_DEP_NPPIDEI "NPPC")
+set(CUDAlibs_DEP_NPPIF "NPPC")
+set(CUDAlibs_DEP_NPPIG "NPPC")
+set(CUDAlibs_DEP_NPPIM "NPPC")
+set(CUDAlibs_DEP_NPPIST "NPPC")
+set(CUDAlibs_DEP_NPPISU "NPPC")
+set(CUDAlibs_DEP_NPPITC "NPPC")
+set(CUDAlibs_DEP_NPPS "NPPC")
+set(CUDAlibs_DEP_NVBLAS "CUBLAS")
+
+# ------------------------------------------------------------------------------
+
+if(NOT CUDAlibs_FIND_COMPONENTS OR CUDAlibs_FIND_COMPONENTS STREQUAL "BASIC")
+  set(CUDAlibs_FIND_COMPONENTS "CUDART;CUBLAS;CUFFT")
+elseif(CUDAlibs_FIND_COMPONENTS STREQUAL "ALL")
+  set(CUDAlibs_FIND_COMPONENTS ${CUDAlibs_ALL_LIBS})
+endif()
+
+foreach(COMPONENT ${CUDAlibs_FIND_COMPONENTS})
+  string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
+
+  if (${UPPERCOMPONENT} IN_LIST CUDAlibs_ALL_LIBS)
+    cuda_find_library(${UPPERCOMPONENT})
+    foreach(_dep "${CUDAlibs_DEP_${UPPERCOMPONENT}}")
+      if(NOT "${_dep}" STREQUAL "")
+	cuda_find_library(${_dep})
+      endif()
+    endforeach()
+  else()
+    message(FATAL_ERROR "Unknown component: ${COMPONENT}")
+  endif()
+
+  mark_as_advanced(
+    CUDAlibs_${UPPERCOMPONENT}_LIB
+    CUDAlibs_${UPPERCOMPONENT}_INCLUDE_DIR)
+endforeach()
+
+# ==============================================================================
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CUDAlibs
+  FOUND_VAR CUDAlibs_FOUND
+  REQUIRED_VARS ${CUDAlibs_REQUIRED_VARS})
+
+# ==============================================================================
+
+if(CUDAlibs_FOUND)
+  # Inspired by FindBoost.cmake
+  foreach(COMPONENT ${CUDAlibs_FIND_COMPONENTS})
+    string(TOUPPER ${COMPONENT} UPPERCOMPONENT)
+
+    if(NOT TARGET CUDAlibs::HEADERS)
+      add_library(CUDAlibs::${UPPERCOMPONENT} INTERFACE)
+      target_include_directories(CUDAlibs::${UPPERCOMPONENT} PUBLIC ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+    endif()
+    
+    if(NOT TARGET CUDAlibs::${UPPERCOMPONENT} AND CUDAlibs_${UPPERCOMPONENT}_FOUND)
+      get_filename_component(LIB_EXT "${CUDAlibs_${UPPERCOMPONENT}_LIB}" EXT)
+      if(LIB_EXT STREQUAL ".a" OR LIB_EXT STREQUAL ".lib")
+        set(LIB_TYPE STATIC)
+      else()
+        set(LIB_TYPE SHARED)
+      endif()
+
+      message(STATUS "CUDAlibs::${UPPERCOMPONENT}")
+      
+      add_library(CUDAlibs::${UPPERCOMPONENT} ${LIB_TYPE} IMPORTED GLOBAL)
+      set_target_properties(CUDAlibs::${UPPERCOMPONENT} PROPERTIES
+	IMPORTED_LOCATION "${CUDAlibs_${UPPERCOMPONENT}_LIB}"
+        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
+
+      # ------------------------------------------------------------------------
+      
+      set(_dependent_libraries)
+      foreach(_dep "${CUDAlibs_DEP_${UPPERCOMPONENT}}")
+	list(APPEND _dependent_libraries ${_dep})
+      endforeach()
+
+      if(NOT "${_dependent_libraries}" STREQUAL "")
+	message(STATUS "Adding dependencies: ${_dependent_libraries}")
+	set_target_properties(CUDAlibs::${UPPERCOMPONENT} PROPERTIES
+          INTERFACE_LINK_LIBRARIES "${_dependent_libraries}")
+      endif()
+    endif()
+  endforeach()
+
+  # ----------------------------------------------------------------------------
+
+  if(NOT CUDAlibs_FIND_QUIETLY)
+    message(STATUS "CUDAlibs_FOUND   :${CUDAlibs_FOUND}:  - set to true if the libraries where found")
+  endif()
+endif()
+
+# ==============================================================================
+
+mark_as_advanced(
+  CUDAlibs_FOUND
+  )
+

--- a/cmake/FindLAPACKE.cmake
+++ b/cmake/FindLAPACKE.cmake
@@ -26,7 +26,7 @@
 #
 #   LAPACKE_FOUND            - True if headers and requested libraries were found
 #   LAPACKE_INCLUDE_DIRS     - LAPACKE include directories
-#   LAPACKE_LIBRARIES        - Boost component libraries to be linked
+#   LAPACKE_LIBRARIES        - LAPACKE component libraries to be linked
 #
 #
 # This module reads hints about search locations from variables

--- a/cmake/bart_install.cmake
+++ b/cmake/bart_install.cmake
@@ -5,7 +5,7 @@
 
 include(GNUInstallDirs)
 
-set(INSTALL_CONFIGDIR  ${CMAKE_INSTALL_LIBDIR}/cmake/BART)
+set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/BART)
 set(INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/bart)
 
 # ==============================================================================
@@ -52,15 +52,12 @@ install(TARGETS bartmain
 # Now take care of exporting all the information for inclusion in other CMake
 # projects
 
-set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/BART)
-
-
 # Write a CMake file with information about the version of BART being compiled
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/BARTConfigVersion.cmake
   VERSION "${BART_VERSION_MAJOR}.${BART_VERSION_MINOR}.${BART_VERSION_PATCH}"
-  COMPATIBILITY AnyNewerVersion)
+  COMPATIBILITY SameMajorVersion)
 
 # Write a CMake config file
 configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/BARTConfig.cmake.in
@@ -71,9 +68,10 @@ configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/BARTConfig.cmake.in
 install(FILES
   ${CMAKE_CURRENT_LIST_DIR}/BARTFindBLASlib.cmake
   ${CMAKE_CURRENT_LIST_DIR}/FindATLAS.cmake
+  ${CMAKE_CURRENT_LIST_DIR}/FindFFTW.cmake
   ${CMAKE_CURRENT_LIST_DIR}/FindLAPACKE.cmake
-  ${CMAKE_CURRENT_LIST_DIR}/FindOpenBLAS.cmake
   ${CMAKE_CURRENT_LIST_DIR}/FindlibFlame.cmake
+  ${CMAKE_CURRENT_LIST_DIR}/FindOpenBLAS.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/BARTConfig.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/BARTConfigVersion.cmake
   DESTINATION ${INSTALL_CONFIGDIR}
@@ -83,13 +81,14 @@ install(FILES
 # Write a CMake file with all the targets information
 export(EXPORT bart-targets FILE ${CMAKE_CURRENT_BINARY_DIR}/BARTTargets.cmake NAMESPACE BART::)
 
-# Install the CMake target file
+# Install the general CMake target file
 install(EXPORT bart-targets
   FILE BARTTargets.cmake
   NAMESPACE BART::
   DESTINATION ${INSTALL_CONFIGDIR}
   )
 
+# Install the CMake target file for embedding
 install(EXPORT bart-targets-for-embedding
   FILE BARTTargetsForEmbedding.cmake
   NAMESPACE BART::
@@ -97,6 +96,7 @@ install(EXPORT bart-targets-for-embedding
   COMPONENT for_embedding
   )
 
+# Register BART in user package directory
 export(PACKAGE BART)
 
 # ==============================================================================


### PR DESCRIPTION
Now all the CMake FindXXX.cmake are up to modern standards using imported targets wherever possible.
Also CUDA compilation with CMake >= 3.8 uses the builtin support instead of the FindCUDA module.

Since you already require GCC 5 in order to compiler BART, I also made a few changes to `mmiocc.cc` to use C++11.