### PR TITLE
Improvement for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,15 @@ ALLDEPS = $(shell find $(srcdir) utests -name ".*.d")
 
 # Compilation flags
 
-OPT = -O3 -ffast-math
 CPPFLAGS ?= -Wall -Wextra
 CFLAGS ?= $(OPT) -Wmissing-prototypes
 CXXFLAGS ?= $(OPT)
+
+OPT = -ffast-math
+ifneq ($(NOOPTIMIZATION), 1)
+	OPT_LEVEL ?= 3
+	OPT += -O$(OPT_LEVEL)
+endif
 
 ifeq ($(BUILDTYPE), MacOSX)
 	CC ?= gcc-mp-6
@@ -148,7 +153,12 @@ MATLAB_BASE ?= /usr/local/matlab/
 
 ISMRM_BASE ?= /usr/local/ismrmrd/
 
-
+# Additional Library
+ifeq ($(ADDITIONAL_LIBRARY), )
+	ADDITIONAL_LIBRARY := 
+else
+	ADDITIONAL_LIBRARY := -L$(ADDITIONAL_LIBRARY)
+endif
 
 # Main build targets are defined in build_targets.mk so that both CMake and Make can use the same definitions
 # set values for TBASE TFLP TNUM TRECO TCALIB TMRI TSIM TIO in build_targets.mk
@@ -289,21 +299,30 @@ endif
 # BLAS/LAPACK
 
 ifeq ($(ACML),1)
-BLAS_H := -I$(ACML_BASE)/include
-BLAS_L := -L$(ACML_BASE)/lib -lgfortran -lacml_mp -Wl,-rpath $(ACML_BASE)/lib
-CPPFLAGS += -DUSE_ACML
+	BLAS_H := -I$(ACML_BASE)/include
+	BLAS_L := -L$(ACML_BASE)/lib -lgfortran -lacml_mp -Wl,-rpath $(ACML_BASE)/lib
+	CPPFLAGS += -DUSE_ACML
 else
-BLAS_H := -I$(BLAS_BASE)/include
-ifeq ($(BUILDTYPE), MacOSX)
-BLAS_L := -L$(BLAS_BASE)/lib -lopenblas
-else
-ifeq ($(NOLAPACKE),1)
-BLAS_L := -L$(BLAS_BASE)/lib -llapack -lblas
-CPPFLAGS += -Isrc/lapacke
-else
-BLAS_L := -L$(BLAS_BASE)/lib -llapacke -lblas
-endif
-endif
+	BLAS_H := -I$(BLAS_BASE)/include
+	BLAS_L := -L$(BLAS_BASE)/lib
+	ifeq ($(BUILDTYPE), MacOSX)
+		BLAS_L += -lopenblas
+	else
+		ifeq ($(NOLAPACKE),1)
+			BLAS_L += -llapack
+			CPPFLAGS += -Isrc/lapacke
+		else
+			BLAS_L += -llapacke
+		endif
+		ifeq ($(OPENBLAS),1)
+			BLAS_L += -lopenblas
+		else
+			BLAS_L += -lblas
+		endif
+	endif
+	ifeq ($(GFORTRAN),1)
+		BLAS_L += -lgfortran
+	endif
 endif
 
 
@@ -385,7 +404,6 @@ BLAS_L += -llapack -lblas -lgfortran -lquadmath
 endif
 
 
-
 # Modules
 
 .LIBPATTERNS := lib%.a
@@ -464,18 +482,18 @@ endif
 
 .SECONDEXPANSION:
 $(TARGETS): % : src/main.c $(srcdir)/%.o $$(MODULES_%) $(MODULES)
-	$(CC) $(LDFLAGS) $(CFLAGS) $(CPPFLAGS) -Dmain_real=main_$@ -o $@ $+ $(FFTW_L) $(CUDA_L) $(BLAS_L) $(PNG_L) $(ISMRM_L) -lm
+	$(CC) $(LDFLAGS) $(CFLAGS) $(CPPFLAGS) -Dmain_real=main_$@ -o $@ $+ $(FFTW_L) $(CUDA_L) $(BLAS_L) $(PNG_L) $(ISMRM_L) $(ADDITIONAL_LIBRARY) -lm
 #	rm $(srcdir)/$@.o
 
 UTESTS=$(shell $(root)/utests/utests-collect.sh ./utests/$@.c)
 
 .SECONDEXPANSION:
 $(UTARGETS): % : utests/utest.c utests/%.o $$(MODULES_%) $(MODULES)
-	$(CC) $(LDFLAGS) $(CFLAGS) $(CPPFLAGS) -DUTESTS="$(UTESTS)" -o $@ $+ $(FFTW_L) $(CUDA_L) $(BLAS_L) -lm
+	$(CC) $(LDFLAGS) $(CFLAGS) $(CPPFLAGS) -DUTESTS="$(UTESTS)" -o $@ $+ $(FFTW_L) $(CUDA_L) $(BLAS_L) $(ADDITIONAL_LIBRARY) -lm
 
 
 # linker script version - does not work on MacOS X
-#	$(CC) $(LDFLAGS) -Wl,-Tutests/utests.ld $(CFLAGS) -o $@ $+ $(FFTW_L) $(CUDA_L) $(BLAS_L) -lm
+#	$(CC) $(LDFLAGS) -Wl,-Tutests/utests.ld $(CFLAGS) -o $@ $+ $(FFTW_L) $(CUDA_L) $(BLAS_L) $(ADDITIONAL_LIBRARY) -lm
 
 clean:
 	rm -f `find $(srcdir) -name "*.o"`


### PR DESCRIPTION
same as #156 , try if it is problem of file encoding

I finally worked out with bart on CentOS 6.8,
I build with OPENBLAS and GFORTRAN,  but Makefile must be modified to make things work,
so I'd like to contribute some modification of Makefile for better build experience,
this is the summery of changes :

  1. add ADDITIONAL_LIBRARY, add extra library search path
  2. add NOOPTIMIZATION, for debug purpose
  3. add OPENBLAS && GFORTRAN, both libraries can be specified directly

Thanks