### PR TITLE
FFTW Wisdom + Minor changes.

### DIFF
--- a/.gitignore.main
+++ b/.gitignore.main
@@ -28,6 +28,9 @@ src/misc/version.inc
 # noise simulations
 save/nsv/*.dat
 
+# fftw wisdoms
+save/fftw/*.fftw
+
 # ctags
 tags
 GTAGS

--- a/save/fftw/README.txt
+++ b/save/fftw/README.txt
@@ -1,0 +1,1 @@
+Saves FFT wisdom.

--- a/src/num/fft.c
+++ b/src/num/fft.c
@@ -1,11 +1,13 @@
 /* Copyright 2013-2014. The Regents of the University of California.
  * Copyright 2016-2018. Martin Uecker.
+ * Copyright 2018. Massachusetts Institute of Technology.
  * All rights reserved. Use of this source code is governed by
  * a BSD-style license which can be found in the LICENSE file.
  *
  * Authors:
  * 2011-2018 Martin Uecker <martin.uecker@med.uni-goettingen.de>
  * 2014 Frank Ong <frankong@berkeley.edu>
+ * 2018 Siddharth Iyer <ssi@mit.edu>
  *
  * 
  * FFT. It uses FFTW or CUFFT internally.
@@ -182,8 +184,6 @@ void fftshift(unsigned int N, const long dimensions[N], unsigned long flags, com
 	fftshift2(N, dimensions, flags, strs, dst, strs, src);
 }
 
-
-
 struct fft_plan_s {
 
 	INTERFACE(operator_data_t);
@@ -205,15 +205,28 @@ struct fft_plan_s {
 
 static DEF_TYPEID(fft_plan_s);
 
-
-
 static fftwf_plan fft_fftwf_plan(unsigned int D, const long dimensions[D], unsigned long flags, const long ostrides[D], complex float* dst, const long istrides[D], const complex float* src, bool backwards, bool measure)
 {
+	fftwf_plan fftwf;
+	char* wisdom = NULL;
+
 	unsigned int N = D;
 	fftwf_iodim64 dims[N];
 	fftwf_iodim64 hmdims[N];
 	unsigned int k = 0;
 	unsigned int l = 0;
+
+	char* tbpath = getenv("TOOLBOX_PATH");
+	if (NULL != tbpath) {
+		wisdom = calloc(2048, sizeof(char));
+		sprintf(wisdom, "%s/save/fftw/N_%u_BACKWARD_%d_FLAGS_%lu_DIMS", tbpath, D, backwards, flags);
+		for (long k = 0; k < N; k++)
+			sprintf(wisdom, "%s_%lu", wisdom, dimensions[k]);
+		sprintf(wisdom, "%s.fftw", wisdom);
+	}
+
+	if (NULL != wisdom)
+		fftwf_import_wisdom_from_filename(wisdom);
 
 	//FFTW seems to be fine with this
 	//assert(0 != flags); 
@@ -236,11 +249,12 @@ static fftwf_plan fft_fftwf_plan(unsigned int D, const long dimensions[D], unsig
 		}
 	}
 
-	fftwf_plan fftwf;
-
 	#pragma omp critical
 	fftwf = fftwf_plan_guru64_dft(k, dims, l, hmdims, (complex float*)src, dst,
 				backwards ? 1 : (-1), measure ? FFTW_MEASURE : FFTW_ESTIMATE);
+
+	if (NULL != wisdom)
+		fftwf_export_wisdom_to_filename(wisdom);
 
 	return fftwf;
 }

--- a/src/num/fft.c
+++ b/src/num/fft.c
@@ -205,7 +205,8 @@ struct fft_plan_s {
 
 static DEF_TYPEID(fft_plan_s);
 
-static char* fftw_wisdom_name(unsigned int N, bool backwards, unsigned int flags, const long dims[N]) {
+static char* fftw_wisdom_name(unsigned int N, bool backwards, unsigned int flags, const long dims[N])
+{
 
 	char* tbpath = getenv("TOOLBOX_PATH");
 	if (NULL == tbpath)
@@ -213,10 +214,10 @@ static char* fftw_wisdom_name(unsigned int N, bool backwards, unsigned int flags
 	char* loc  = NULL;
 
 	// Space for path and null terminator.
-	size_t space = snprintf(loc , 0, "%s/save/fftw/N_%d_BACKWARD_%d_FLAGS_%d_DIMS", tbpath, N, backwards, flags);
+	size_t space = snprintf(loc, 0, "%s/save/fftw/N_%d_BACKWARD_%d_FLAGS_%d_DIMS", tbpath, N, backwards, flags);
 	// Space for dimensions.
 	for (size_t idx = 0; idx < N; idx ++)
-		space += snprintf(loc, 0, "_%lu", dims[N]);
+		space += snprintf(loc, 0, "_%lu", dims[idx]);
 	// Space for extension.
 	space += snprintf(loc, 0, ".fftw");
 	// Space for null terminator.

--- a/src/num/fft.c
+++ b/src/num/fft.c
@@ -210,35 +210,30 @@ static char* fftw_wisdom_name(unsigned int N, bool backwards, unsigned int flags
 	char* tbpath = getenv("TOOLBOX_PATH");
 	if (NULL == tbpath)
 		return NULL;
+	char* loc  = NULL;
 
-	char STR_PATH[] = "/save/fftw/";
-	char STR_N[]    = "N_";
-	char STR_BACK[] = "_BACKWARD_";
-	char STR_FLAG[] = "_FLAGS_";
-	char STR_DIMS[] = "_DIMS";
-
-	int space[] = {strlen(tbpath), strlen(STR_PATH), strlen(STR_N), floor(log10(N)) + 1, strlen(STR_BACK), 1, strlen(STR_FLAG), floor(log10(flags)) + 1, strlen(STR_DIMS)};
-	size_t total = 1;                         // Start from one for null terminator.
-	for (size_t idx = 0; idx < sizeof(space)/sizeof(int); idx ++)
-		total += space[idx];                    // Space for base path.
+	// Space for path and null terminator.
+	size_t space = snprintf(loc , 0, "%s/save/fftw/N_%d_BACKWARD_%d_FLAGS_%d_DIMS", tbpath, N, backwards, flags);
+	// Space for dimensions.
 	for (size_t idx = 0; idx < N; idx ++)
-		total += (2 + floor(log10(dims[idx]))); // Space for dimensions.
-	total += 5;                               // Space for extension.
+		space += (snprintf(loc, 0, "_%lu", dims[N]) - 1);
+	// Space for extension.
+	space += snprintf(loc, 0, ".fftw") - 1;
 
-	char* name = calloc(total, sizeof(char));
-	sprintf(name, "%s%s%s%u%s%u%s%u%s", tbpath, STR_PATH, STR_N, N, STR_BACK, backwards, STR_FLAG, flags, STR_DIMS);
+	loc = calloc(space, sizeof(char));
+	sprintf(loc , "%s/save/fftw/N_%d_BACKWARD_%d_FLAGS_%d_DIMS", tbpath, N, backwards, flags);
 
-	char tmp[64];                             // Safe assumption since largest int in a 64 bit system is less than 20 places in base 10.
+	char tmp[64];
 	for (size_t idx = 0; idx < N; idx++) {
 		sprintf(tmp, "_%lu", dims[idx]);
-		strcat(name, tmp);
+		strcat(loc, tmp);
 	}
 
 	sprintf(tmp, ".fftw");
-	strcat(name, tmp);
-	name[total - 1] = '\0';
+	strcat(loc, tmp);
+	loc[space - 1] = '\0';
 
-	return name;
+	return loc;
 }
 
 static fftwf_plan fft_fftwf_plan(unsigned int D, const long dimensions[D], unsigned long flags, const long ostrides[D], complex float* dst, const long istrides[D], const complex float* src, bool backwards, bool measure)

--- a/src/num/fft.c
+++ b/src/num/fft.c
@@ -216,9 +216,11 @@ static char* fftw_wisdom_name(unsigned int N, bool backwards, unsigned int flags
 	size_t space = snprintf(loc , 0, "%s/save/fftw/N_%d_BACKWARD_%d_FLAGS_%d_DIMS", tbpath, N, backwards, flags);
 	// Space for dimensions.
 	for (size_t idx = 0; idx < N; idx ++)
-		space += (snprintf(loc, 0, "_%lu", dims[N]) - 1);
+		space += snprintf(loc, 0, "_%lu", dims[N]);
 	// Space for extension.
-	space += snprintf(loc, 0, ".fftw") - 1;
+	space += snprintf(loc, 0, ".fftw");
+	// Space for null terminator.
+	space += 1;
 
 	loc = calloc(space, sizeof(char));
 	sprintf(loc , "%s/save/fftw/N_%d_BACKWARD_%d_FLAGS_%d_DIMS", tbpath, N, backwards, flags);

--- a/src/wave.c
+++ b/src/wave.c
@@ -234,14 +234,40 @@ int main_wave(int argc, char* argv[])
 	estimate_pattern(DIMS, kspc_dims, ~FFT_FLAGS, mask, kspc);
 	debug_printf(DP_INFO, "Done.\n");
 
-	debug_printf(DP_INFO, "Creating linear operators... ");
-	const struct linop_s* E   = linop_espirit_create(sx, sy, sz, nc, md, maps);
-	const struct linop_s* R   = linop_reshape_create(wx, sx, sy, sz, nc);
-	const struct linop_s* Fx  = linop_fx_create(wx, sy, sz, nc);
-	const struct linop_s* W   = linop_wave_create(wx, sy, sz, nc, wave);
+	debug_printf(DP_INFO, "Creating linear operators:\n");
+
+	double t1;
+	double t2;
+
+	t1 = timestamp();
+	const struct linop_s* E = linop_espirit_create(sx, sy, sz, nc, md, maps);
+	t2 = timestamp();
+	debug_printf(DP_INFO, "\tE:   %f seconds.\n", t2 - t1);
+
+	t1 = timestamp();
+	const struct linop_s* R = linop_reshape_create(wx, sx, sy, sz, nc);
+	t2 = timestamp();
+	debug_printf(DP_INFO, "\tR:   %f seconds.\n", t2 - t1);
+
+	t1 = timestamp();
+	const struct linop_s* Fx = linop_fx_create(wx, sy, sz, nc);
+	t2 = timestamp();
+	debug_printf(DP_INFO, "\tFx:  %f seconds.\n", t2 - t1);
+
+	t1 = timestamp();
+	const struct linop_s* W = linop_wave_create(wx, sy, sz, nc, wave);
+	t2 = timestamp();
+	debug_printf(DP_INFO, "\tW:   %f seconds.\n", t2 - t1);
+
+	t1 = timestamp();
 	const struct linop_s* Fyz = linop_fyz_create(wx, sy, sz, nc);
+	t2 = timestamp();
+	debug_printf(DP_INFO, "\tFyz: %f seconds.\n", t2 - t1);
+
+	t1 = timestamp();
 	const struct linop_s* M   = linop_samp_create(wx, sy, sz, nc, mask);
-	debug_printf(DP_INFO, "Done.\n");
+	t2 = timestamp();
+	debug_printf(DP_INFO, "\tM:   %f seconds.\n", t2 - t1);
 
 	debug_printf(DP_INFO, "Forward linear operator information:\n");
 	struct linop_s* A = linop_chain(linop_chain(linop_chain(linop_chain(linop_chain(

--- a/src/wave.c
+++ b/src/wave.c
@@ -1,11 +1,14 @@
 /* Copyright 2015. The Regents of the University of California.
  * Copyright 2015. Martin Uecker.
+ * Copyright 2018. Massachusetts Institute of Technology.
+ *
  * All rights reserved. Use of this source code is governed by
  * a BSD-style license which can be found in the LICENSE file.
  *
  * Authors: 
  * 2015 Berkin Bilgic <berkin@nmr.mgh.harvard.edu>
  * 2015 Martin Uecker <martin.uecker@med.uni-goettingen.de>
+ * 2018 Siddharth Iyer <ssi@mit.edu>
  *
  * B Bilgic, BA Gagoski, SF Cauley, AP Fan, JR Polimeni, PE Grant,
  * LL Wald, and K Setsompop, Wave-CAIPI for highly accelerated 3D
@@ -21,13 +24,22 @@
 #include "num/flpmath.h"
 #include "num/fft.h"
 #include "num/init.h"
+#include "num/iovec.h"
+#include "num/ops.h"
+#ifdef USE_CUDA
+#include "num/gpuops.h"
+#endif
 
 #include "iter/iter.h"
 #include "iter/lsqr.h"
+#include "iter/misc.h"
 
 #include "linops/linop.h"
-#include "linops/sampling.h"
+#include "linops/fmac.h"
 #include "linops/someops.h"
+#include "linops/realval.h"
+
+#include "sense/optcom.h"
 
 #include "misc/debug.h"
 #include "misc/mri.h"
@@ -36,202 +48,354 @@
 #include "misc/misc.h"
 #include "misc/opts.h"
 
-#include "sense/model.h"
-#include "sense/optcom.h"
-
 #include "wavelet/wavthresh.h"
 
+static const char usage_str[] = "<maps> <wave> <kspace> <output>";
+static const char help_str[]  = 
+	"Perform a wave-caipi reconstruction.\n\n"
+	"Conventions:\n"
+	"  * (sx, sy, sz) - Spatial dimensions.\n"
+	"  * wx           - Extended FOV in READ_DIM due to\n"
+	"                   wave's voxel spreading.\n"
+	"  * (nc, md)     - Number of channels and ESPIRiT's \n"
+	"                   extended-SENSE model operator\n"
+	"                   dimensions (or # of maps).\n"
+	"Expected dimensions:\n"
+	"  * maps    - (   sx, sy, sz, nc, md)\n"
+	"  * wave    - (   wx, sy, sz,  1,  1)\n"
+	"  * phi     - (    1,  1,  1,  1,  1)\n"
+	"  * output  - (   sx, sy, sz,  1, md)\n"
+	"  * reorder - (    n,  3,  1,  1,  1)\n"
+	"  * table   - (   wx, nc,  n,  1,  1)";
 
-// create wavecaipi operator
-
-static struct linop_s* wavecaipi_create(const long dims[DIMS], long img_read, const complex float* wave)
+/* Helper function to print out operator dimensions. */
+static void print_opdims(const struct linop_s* op) 
 {
-	// Wave-CAIPI linear operator created by chaining zero-padding, readout fft, 
-	// psf multiplication, ky-kz fft
-    
-	long img_dims[DIMS];
-	md_select_dims(DIMS, FFT_FLAGS|COIL_FLAG, img_dims, dims);
-	img_dims[READ_DIM] = img_read;
-    
-	struct linop_s* fft_read = linop_fft_create(DIMS, dims, READ_FLAG);
-	struct linop_s* fft_yz = linop_fft_create(DIMS, dims, PHS1_FLAG|PHS2_FLAG);
-	struct linop_s* resize = linop_resize_create(DIMS, dims, img_dims);
-	struct linop_s* wavemod = linop_cdiag_create(DIMS, dims, FFT_FLAGS, wave);
-
-	struct linop_s* wc_op = linop_chain(linop_chain(linop_chain(resize, fft_read), wavemod), fft_yz);
-
-	linop_free(fft_read);
-	linop_free(fft_yz);
-	linop_free(resize);
-	linop_free(wavemod);
-
-	return wc_op;
+	const struct iovec_s* domain   = linop_domain(op);
+	const struct iovec_s* codomain = linop_codomain(op);
+	debug_printf(DP_INFO, "\tDomain:   ");
+	debug_print_dims(DP_INFO, domain->N, domain->dims);
+	debug_printf(DP_INFO, "\tCodomain: ");
+	debug_print_dims(DP_INFO, codomain->N, codomain->dims);
 }
 
+/* ESPIRiT operator. */
+static const struct linop_s* linop_espirit_create(long sx, long sy, long sz, long nc, long md, complex float* maps)
+{
+	long max_dims[] = { [0 ... DIMS - 1] = 1};
+	max_dims[0] = sx;
+	max_dims[1] = sy;
+	max_dims[2] = sz;
+	max_dims[3] = nc;
+	max_dims[4] = md;
+	const struct linop_s* E = linop_fmac_create(DIMS, max_dims, MAPS_FLAG, COIL_FLAG, ~(FFT_FLAGS|MAPS_FLAG|COIL_FLAG), maps);
+	return E;
+}
 
+/* Resize operator. */
+static const struct linop_s* linop_reshape_create(long wx, long sx, long sy, long sz, long nc)
+{
+	long input_dims[] = { [0 ... DIMS - 1] = 1};
+	input_dims[0] = sx;
+	input_dims[1] = sy;
+	input_dims[2] = sz;
+	input_dims[3] = nc;
+	long output_dims[DIMS];
+	md_copy_dims(DIMS, output_dims, input_dims);
+	output_dims[0] = wx;
+	struct linop_s* R = linop_resize_create(DIMS, output_dims, input_dims);
+	return R;
+}
 
-static const char usage_str[] = "<kspace> <sensitivities> <wave> <output>";
-static const char help_str[] = "Perform iterative wavecaipi reconstruction.";
+/* Fx operator. */
+static const struct linop_s* linop_fx_create(long wx, long sy, long sz, long nc)
+{
+	long dims[] = { [0 ... DIMS - 1] = 1};
+	dims[0] = wx;
+	dims[1] = sy;
+	dims[2] = sz;
+	dims[3] = nc;
+	struct linop_s* Fx = linop_fft_create(DIMS, dims, READ_FLAG);
+	return Fx;
+}
 
+/* Wave operator. */
+static const struct linop_s* linop_wave_create(long wx, long sy, long sz, long nc, complex float* psf)
+{
+	long dims[] = { [0 ... DIMS - 1] = 1};
+	dims[0] = wx;
+	dims[1] = sy;
+	dims[2] = sz;
+	dims[3] = nc;
+	struct linop_s* W = linop_cdiag_create(DIMS, dims, FFT_FLAGS, psf);
+	return W;
+}
 
+/* Fyz operator. */
+static const struct linop_s* linop_fyz_create(long wx, long sy, long sz, long nc)
+{
+	long dims[] = { [0 ... DIMS - 1] = 1};
+	dims[0] = wx;
+	dims[1] = sy;
+	dims[2] = sz;
+	dims[3] = nc;
+	struct linop_s* Fyz = linop_fft_create(DIMS, dims, PHS1_FLAG|PHS2_FLAG);
+	return Fyz;
+}
+
+/* Sampling operator. */
+static const struct linop_s* linop_samp_create(long wx, long sy, long sz, long nc, complex float* mask)
+{
+	long dims[] = { [0 ... DIMS - 1] = 1};
+	dims[0] = wx;
+	dims[1] = sy;
+	dims[2] = sz;
+	dims[3] = nc;
+	struct linop_s* M = linop_cdiag_create(DIMS, dims, FFT_FLAGS, mask);
+	return M;
+}
+
+enum algo_t { CG, IST, FISTA };
 
 int main_wave(int argc, char* argv[])
 {
-	float lambda = 0.;
-	float step = 0.95;
+	double start_time = timestamp();
 
-	bool l1wav = false;
-	bool hogwild = false;
-	bool randshift = true;
-	bool adjoint = false;
-	int maxiter = 50;
+	float lambda    = 1E-5;
+	int   maxiter   = 300;
+	float step      = 0.5;
+	float tol       = 1.E-3;
+	bool  wav       = false;
+	bool  fista     = false;
+	bool  hgwld     = false;
+	float cont      = 1;
+	float eval      = -1;
+	int   gpun      = -1;
+	bool  rvc       = false;
 
 	const struct opt_s opts[] = {
-
-		OPT_SET('l',  &l1wav, "use L1 penalty"),
-		OPT_SET('a', &adjoint, "adjoint"),
-		OPT_INT('i', &maxiter, "iter", "max. iterations"),
-		OPT_FLOAT('r', &lambda, "lambda", "regularization parameter"),
+		OPT_FLOAT( 'r', &lambda,  "lambda", "Soft threshold lambda for wavelet or locally low rank."),
+		OPT_INT(   'i', &maxiter, "mxiter", "Maximum number of iterations."),
+		OPT_FLOAT( 's', &step,    "stepsz", "Step size for iterative method."),
+		OPT_FLOAT( 'c', &cont,    "cntnu",  "Continuation value for IST/FISTA."),
+		OPT_FLOAT( 't', &tol,     "toler",  "Tolerance convergence condition for iterative method."),
+		OPT_FLOAT( 'e', &eval,    "eigvl",  "Maximum eigenvalue of normal operator, if known."),
+		OPT_INT(   'g', &gpun,    "gpunm",  "GPU device number."),
+		OPT_SET(   'f', &fista,             "Reconstruct using FISTA instead of IST."),
+		OPT_SET(   'H', &hgwld,             "Use hogwild in IST/FISTA."),
+		OPT_SET(   'w', &wav,               "Use wavelet."),
+		OPT_SET(   'v', &rvc,               "Apply real valued constraint on coefficients."),
 	};
 
 	cmdline(&argc, argv, 4, 4, usage_str, help_str, ARRAY_SIZE(opts), opts);
 
+	debug_printf(DP_INFO, "Loading data... ");
 
-	long map_dims[DIMS];
-	long pat_dims[DIMS];
-	long img_dims[DIMS];
-	long ksp_dims[DIMS];
-	long max_dims[DIMS];
-	long wav_dims[DIMS];
+	long maps_dims[DIMS];
+	complex float* maps = load_cfl(argv[1], DIMS, maps_dims);
 
-	// load kspace and maps and get dimensions
+	long wave_dims[DIMS];
+	complex float* wave = load_cfl(argv[2], DIMS, wave_dims);
 
-	complex float* kspace = load_cfl(argv[1], DIMS, ksp_dims);
-	complex float* maps = load_cfl(argv[2], DIMS, map_dims);
-	complex float* wave = load_cfl(argv[3], DIMS, wav_dims);
+	long kspc_dims[DIMS];
+	complex float* kspc = load_cfl(argv[3], DIMS, kspc_dims);
 
+	debug_printf(DP_INFO, "Done.\n");
 
-	md_copy_dims(DIMS, max_dims, ksp_dims);
-	max_dims[MAPS_DIM] = map_dims[MAPS_DIM];
-
-	md_select_dims(DIMS, ~COIL_FLAG, pat_dims, ksp_dims);
-	md_select_dims(DIMS, ~(COIL_FLAG|READ_FLAG), img_dims, max_dims);
-	img_dims[READ_DIM] = map_dims[READ_DIM];
-
-
-	for (int i = 1; i < 4; i++)	// sizes2[4] may be > 1
-		if (ksp_dims[i] != map_dims[i])
-			error("Dimensions of kspace and sensitivities do not match!\n");
-
-	// FIXME: add more sanity checking of dimensions
-
-	assert(1 == ksp_dims[MAPS_DIM]);
-
-	num_init();
-
-	// initialize sampling pattern
-
-	complex float* pattern = md_alloc(DIMS, pat_dims, CFL_SIZE);
-	estimate_pattern(DIMS, ksp_dims, COIL_FLAG, pattern, kspace);
-
-	// print some statistics
-
-	size_t T = md_calc_size(DIMS, pat_dims);
-	long samples = (long)pow(md_znorm(DIMS, pat_dims, pattern), 2.);
-	debug_printf(DP_INFO, "Size: %ld Samples: %ld Acc: %.2f\n", T, samples, (float)T / (float)samples); 
-
-
-	// apply scaling
-
-	float scaling = estimate_scaling(ksp_dims, NULL, kspace);
-
-	if (scaling != 0.)
-		md_zsmul(DIMS, ksp_dims, kspace, kspace, 1. / scaling);
-
-
-	const struct operator_p_s* thresh_op = NULL;
-
-	// wavelet operator
-	if (l1wav) {
-
-		long minsize[DIMS] = { [0 ... DIMS - 1] = 1 };
-		minsize[0] = MIN(img_dims[0], 16);
-		minsize[1] = MIN(img_dims[1], 16);
-		minsize[2] = MIN(img_dims[2], 16);
-
-		thresh_op = prox_wavelet_thresh_create(DIMS, img_dims, FFT_FLAGS, 0u, minsize, lambda, randshift);
-	}
-    
-
-	complex float* image = create_cfl(argv[4], DIMS, img_dims);
-	md_clear(DIMS, img_dims, image, CFL_SIZE);
-
-
-	fftmod(DIMS, ksp_dims, FFT_FLAGS, kspace, kspace);
-	fftmod(DIMS, map_dims, FFT_FLAGS, maps, maps);
-
-//	initialize iterative algorithm
-    
-	italgo_fun_t italgo = NULL;
-	iter_conf* iconf = NULL;
-
-	struct iter_conjgrad_conf cgconf;
-	struct iter_fista_conf fsconf;
-
-	if (!l1wav) {
-
-		// configuration for CG recon 
-        	cgconf = iter_conjgrad_defaults;
-		cgconf.maxiter = maxiter;        // max no of iterations
-		cgconf.l2lambda = lambda;   // regularization parameter
-		cgconf.tol = 1.E-3;         // cg tolerance     
-
-		italgo = iter_conjgrad;
-		iconf = CAST_UP(&cgconf);
-
-	} else {
-
-		// use FISTA for wavelet regularization
-		fsconf = iter_fista_defaults;
-		fsconf.maxiter = maxiter;
-		fsconf.step = step;
-		fsconf.hogwild = hogwild;
-
-		italgo = iter_fista;
-		iconf = CAST_UP(&fsconf);
-	}
-
-
-	// create sense maps operator
-//	struct linop_s* mapsop = maps_create(map_dims, FFT_FLAGS|COIL_FLAG|MAPS_FLAG, maps, false);
-
-	md_zsmul(DIMS, map_dims, maps, maps, 1. / sqrt((double)(ksp_dims[0] * ksp_dims[1] * ksp_dims[2])));
-	struct linop_s* mapsop = maps2_create(map_dims, map_dims, img_dims, maps);
-    
-	// create wave caipi operator
-	struct linop_s* waveop = wavecaipi_create(ksp_dims, img_dims[READ_DIM], wave);
-
-	// create sense operator by chaining coil sens and wave operators    
-	struct linop_s* sense_op = linop_chain(mapsop, waveop);
-
-	// create forward operator by adding sampling mask to sense operator
-	struct linop_s* forward = linop_chain(sense_op, linop_sampling_create(ksp_dims, pat_dims, pattern));
-
-	struct lsqr_conf lsqr_conf = { 0., false };
-
-	// reconstruction with LSQR
-
-	if (adjoint)
-		linop_adjoint(forward, DIMS, img_dims, image, DIMS, ksp_dims, kspace);
+	if (gpun >= 0)
+		num_init_gpu_device(gpun);
 	else
-	        lsqr(DIMS, &lsqr_conf, italgo, iconf, forward, thresh_op, img_dims, image, ksp_dims, kspace, NULL);
-        
-	unmap_cfl(DIMS, map_dims, maps);
-	unmap_cfl(DIMS, wav_dims, wave);
-	unmap_cfl(DIMS, ksp_dims, kspace);
-	unmap_cfl(DIMS, img_dims, image);
+		num_init();
+
+	int wx = wave_dims[0];
+	int sx = maps_dims[0];
+	int sy = maps_dims[1];
+	int sz = maps_dims[2];
+	int nc = maps_dims[3];
+	int md = maps_dims[4];
+
+	long recon_dims[] = { [0 ... DIMS - 1] = 1 };
+	recon_dims[0] = sx;
+	recon_dims[1] = sy;
+	recon_dims[2] = sz;
+	recon_dims[4] = md;
+
+	debug_printf(DP_INFO, "FFTMOD maps and kspc... ");
+	fftmod(DIMS, kspc_dims, FFT_FLAGS, kspc, kspc);
+	fftmod(DIMS, maps_dims, FFT_FLAGS, maps, maps);
+	debug_printf(DP_INFO, "Done.\n");
+
+	debug_printf(DP_INFO, "Estimating sampling mask... ");
+	long mask_dims[] = { [0 ... DIMS - 1] = 1 };
+	mask_dims[0] = wx;
+	mask_dims[1] = sy;
+	mask_dims[2] = sz;
+	complex float* mask = md_calloc(DIMS, mask_dims, CFL_SIZE);
+	estimate_pattern(DIMS, kspc_dims, ~FFT_FLAGS, mask, kspc);
+	debug_printf(DP_INFO, "Done.\n");
+
+	debug_printf(DP_INFO, "Creating linear operators... ");
+	const struct linop_s* E   = linop_espirit_create(sx, sy, sz, nc, md, maps);
+	const struct linop_s* R   = linop_reshape_create(wx, sx, sy, sz, nc);
+	const struct linop_s* Fx  = linop_fx_create(wx, sy, sz, nc);
+	const struct linop_s* W   = linop_wave_create(wx, sy, sz, nc, wave);
+	const struct linop_s* Fyz = linop_fyz_create(wx, sy, sz, nc);
+	const struct linop_s* M   = linop_samp_create(wx, sy, sz, nc, mask);
+	debug_printf(DP_INFO, "Done.\n");
+
+	debug_printf(DP_INFO, "Forward linear operator information:\n");
+	struct linop_s* A = linop_chain(linop_chain(linop_chain(linop_chain(linop_chain(
+		E, R), Fx), W), Fyz), M);
+
+	if (rvc == true) {
+		debug_printf(DP_INFO, "\tDomain is restricted to real numbers.\n");
+		struct linop_s* tmp = A;
+		struct linop_s* rvcop = linop_realval_create(DIMS, linop_domain(A)->dims);
+
+		A = linop_chain(rvcop, tmp);
+
+		linop_free(rvcop);
+		linop_free(tmp);
+	}
+
+	linop_free(E);
+	linop_free(R);
+	linop_free(Fx);
+	linop_free(W);
+	linop_free(Fyz);
+	linop_free(M);
+
+	print_opdims(A);
+
+	if (eval < 0)	
+#ifdef USE_CUDA
+		eval = (gpun >= 0) ? estimate_maxeigenval_gpu(A->normal) : estimate_maxeigenval(A->normal);
+#else
+		eval = estimate_maxeigenval(A->normal);
+#endif
+	debug_printf(DP_INFO, "\tMax eval: %.2e\n", eval);
+	step /= eval;
+
+	debug_printf(DP_INFO, "Normalizing kspace... ");
+	float scaling = estimate_scaling(kspc_dims, NULL, kspc);
+	if (scaling != 0.)
+		md_zsmul(DIMS, kspc_dims, kspc, kspc, 1. / scaling);
+	debug_printf(DP_INFO, "Done.\n");
+
+	const struct operator_p_s* T = NULL;
+	long minsize[] = { [0 ... DIMS - 1] = 1 };
+	minsize[0] = MIN(sx, 16);
+	minsize[1] = MIN(sy, 16);
+	minsize[2] = MIN(sz, 16);
+	unsigned int WAVFLAG = (sx > 1) * READ_FLAG | (sy > 1) * PHS1_FLAG | (sz > 2) * PHS2_FLAG;
+
+	enum algo_t algo = CG;
+	if (wav == true) {
+		algo = (fista) ? FISTA : IST;
+		debug_printf(DP_INFO, "Creating wavelet threshold operator... ");
+		T = prox_wavelet_thresh_create(DIMS, recon_dims, WAVFLAG, 0u, minsize, lambda, true);
+		debug_printf(DP_INFO, "Done.\n");
+	}
+
+	italgo_fun2_t italgo = iter2_call_iter;
+	struct iter_call_s iter2_data;
+	SET_TYPEID(iter_call_s, &iter2_data);
+	iter_conf* iconf = CAST_UP(&iter2_data);
+
+	struct iter_conjgrad_conf cgconf = iter_conjgrad_defaults;
+	struct iter_fista_conf    fsconf = iter_fista_defaults;
+	struct iter_ist_conf      isconf = iter_ist_defaults;
+
+	switch(algo) {
+
+		case IST:
+
+			debug_printf(DP_INFO, "Using IST.\n");
+			debug_printf(DP_INFO, "\tLambda:             %0.2e\n", lambda);
+			debug_printf(DP_INFO, "\tMaximum iterations: %d\n", maxiter);
+			debug_printf(DP_INFO, "\tStep size:          %0.2e\n", step);
+			debug_printf(DP_INFO, "\tHogwild:            %d\n", (int) hgwld);
+			debug_printf(DP_INFO, "\tTolerance:          %0.2e\n", tol);
+			debug_printf(DP_INFO, "\tContinuation:       %0.2e\n", cont);
+
+			isconf              = iter_ist_defaults;
+			isconf.step         = step;
+			isconf.maxiter      = maxiter;
+			isconf.tol          = tol;
+			isconf.continuation = cont;
+			isconf.hogwild      = hgwld;
+
+			iter2_data.fun   = iter_ist;
+			iter2_data._conf = CAST_UP(&isconf);
+
+			break;
+
+		case FISTA:
+
+			debug_printf(DP_INFO, "Using FISTA.\n");
+			debug_printf(DP_INFO, "\tLambda:             %0.2e\n", lambda);
+			debug_printf(DP_INFO, "\tMaximum iterations: %d\n", maxiter);
+			debug_printf(DP_INFO, "\tStep size:          %0.2e\n", step);
+			debug_printf(DP_INFO, "\tHogwild:            %d\n", (int) hgwld);
+			debug_printf(DP_INFO, "\tTolerance:          %0.2e\n", tol);
+			debug_printf(DP_INFO, "\tContinuation:       %0.2e\n", cont);
+
+			fsconf              = iter_fista_defaults;
+			fsconf.maxiter      = maxiter;
+			fsconf.step         = step;
+			fsconf.hogwild      = hgwld;
+			fsconf.tol          = tol;
+			fsconf.continuation = cont;
+
+			iter2_data.fun   = iter_fista;
+			iter2_data._conf = CAST_UP(&fsconf);
+
+			break;
+
+		default:
+		case CG:
+
+			debug_printf(DP_INFO, "Using CG.\n");
+			debug_printf(DP_INFO, "\tMaximum iterations: %d\n", maxiter);
+			debug_printf(DP_INFO, "\tTolerance:          %0.2e\n", tol);
+
+			cgconf          = iter_conjgrad_defaults;
+			cgconf.maxiter  = maxiter;
+			cgconf.l2lambda = 0;
+			cgconf.tol      = tol;
+
+			iter2_data.fun   = iter_conjgrad;
+			iter2_data._conf = CAST_UP(&cgconf);
+
+			break;
+
+	}
+
+	complex float* tmp = create_cfl("../../tmp", DIMS, mask_dims);
+  md_copy(DIMS, mask_dims, tmp, mask, CFL_SIZE);
+  unmap_cfl(DIMS, mask_dims, tmp);
+
+	debug_printf(DP_INFO, "Reconstruction... ");
+	complex float* recon = create_cfl(argv[4], DIMS, recon_dims);
+	struct lsqr_conf lsqr_conf = { 0., gpun >= 0 };
+	double recon_start = timestamp();
+	const struct operator_s* J = lsqr2_create(&lsqr_conf, italgo, iconf, NULL, A, NULL, 1, &T, NULL, NULL);
+	operator_apply(J, DIMS, recon_dims, recon, DIMS, kspc_dims, kspc);
+	double recon_end = timestamp();
+	debug_printf(DP_INFO, "Done.\nReconstruction time: %f seconds.\n", recon_end - recon_start);
+
+	debug_printf(DP_INFO, "Cleaning up and saving result... ");
+	operator_free(J);
+	linop_free(A);
+	md_free(mask);
+	unmap_cfl(DIMS, maps_dims, maps);
+	unmap_cfl(DIMS, wave_dims, wave);
+	unmap_cfl(DIMS, kspc_dims, kspc);
+	unmap_cfl(DIMS, recon_dims, recon);
+	debug_printf(DP_INFO, "Done.\n");
+
+	double end_time = timestamp();
+	debug_printf(DP_INFO, "Total time: %f seconds.\n", end_time - start_time);
 
 	return 0;
 }
-
-

--- a/src/wave.c
+++ b/src/wave.c
@@ -277,9 +277,8 @@ int main_wave(int argc, char* argv[])
 	step /= eval;
 
 	debug_printf(DP_INFO, "Normalizing kspace... ");
-	float scaling = estimate_scaling(kspc_dims, NULL, kspc);
-	if (scaling != 0.)
-		md_zsmul(DIMS, kspc_dims, kspc, kspc, 1. / scaling);
+	float norm = md_znorm(DIMS, kspc_dims, kspc);
+	md_zsmul(DIMS, kspc_dims, kspc, kspc, 1. / norm);
 	debug_printf(DP_INFO, "Done.\n");
 
 	const struct operator_p_s* T = NULL;

--- a/src/wave.c
+++ b/src/wave.c
@@ -396,10 +396,6 @@ int main_wave(int argc, char* argv[])
 
 	}
 
-	complex float* tmp = create_cfl("../../tmp", DIMS, mask_dims);
-  md_copy(DIMS, mask_dims, tmp, mask, CFL_SIZE);
-  unmap_cfl(DIMS, mask_dims, tmp);
-
 	debug_printf(DP_INFO, "Reconstruction... ");
 	complex float* recon = create_cfl(argv[4], DIMS, recon_dims);
 	struct lsqr_conf lsqr_conf = { 0., gpun >= 0 };

--- a/src/wshfl.c
+++ b/src/wshfl.c
@@ -719,14 +719,40 @@ int main_wshfl(int argc, char* argv[])
 	coeff_dims[4] = md;
 	coeff_dims[6] = tk;
 
-	debug_printf(DP_INFO, "Creating linear operators... ");
+	debug_printf(DP_INFO, "Creating linear operators: \n");
+
+	double t1;
+	double t2;
+
+	t1 = timestamp();
 	const struct linop_s* E   = linop_espirit_create(sx, sy, sz, nc, md, tk, maps);
+	t2 = timestamp();
+	debug_printf(DP_INFO, "\tE:   %f seconds.\n", t2 - t1);
+
+	t1 = timestamp();
 	const struct linop_s* R   = linop_reshape_create(wx, sx, sy, sz, nc, tk);
+	t2 = timestamp();
+	debug_printf(DP_INFO, "\tR:   %f seconds.\n", t2 - t1);
+
+	t1 = timestamp();
 	const struct linop_s* Fx  = linop_fx_create(wx, sy, sz, nc, tk, false);
+	t2 = timestamp();
+	debug_printf(DP_INFO, "\tFx:  %f seconds.\n", t2 - t1);
+
+	t1 = timestamp();
 	const struct linop_s* W   = linop_wave_create(wx, sy, sz, nc, tk, wave);
+	t2 = timestamp();
+	debug_printf(DP_INFO, "\tW:   %f seconds.\n", t2 - t1);
+
+	t1 = timestamp();
 	const struct linop_s* Fyz = linop_fyz_create(wx, sy, sz, nc, tk, false);
+	t2 = timestamp();
+	debug_printf(DP_INFO, "\tFyz: %f seconds.\n", t2 - t1);
+
+	t1 = timestamp();
 	const struct linop_s* K   = linop_kern_create(gpun >= 0, reorder_dims, reorder, phi_dims, phi, kernel_dims, kernel, table_dims);
-	debug_printf(DP_INFO, "Done.\n");
+	t2 = timestamp();
+	debug_printf(DP_INFO, "\tK:   %f seconds.\n", t2 - t1);
 
 	if (fwd != NULL) {
 

--- a/src/wshfl.c
+++ b/src/wshfl.c
@@ -45,7 +45,6 @@
 #include "linops/fmac.h"
 #include "linops/someops.h"
 #include "linops/realval.h"
-#include "sense/model.h"
 
 #include "misc/debug.h"
 #include "misc/mri.h"
@@ -88,7 +87,7 @@ static const char help_str[]  =
 	"Expected dimensions:\n"
 	"  * maps    - (   sx, sy, sz, nc, md,  1,  1)\n"
 	"  * wave    - (   wx, sy, sz,  1,  1,  1,  1)\n"
-                                "  * phi     - (    1,  1,  1,  1,  1, tf, tk)\n"
+	"  * phi     - (    1,  1,  1,  1,  1, tf, tk)\n"
 	"  * output  - (   sx, sy, sz,  1, md,  1, tk)\n"
 	"  * reorder - (    n,  3,  1,  1,  1,  1,  1)\n"
 	"  * table   - (   wx, nc,  n,  1,  1,  1,  1)";

--- a/src/wshfl.c
+++ b/src/wshfl.c
@@ -719,28 +719,28 @@ int main_wshfl(int argc, char* argv[])
 	coeff_dims[4] = md;
 	coeff_dims[6] = tk;
 
-	debug_printf(DP_INFO, "Creating linear operators: \n");
+	debug_printf(DP_INFO, "Creating linear operators:\n");
 
 	double t1;
 	double t2;
 
 	t1 = timestamp();
-	const struct linop_s* E   = linop_espirit_create(sx, sy, sz, nc, md, tk, maps);
+	const struct linop_s* E = linop_espirit_create(sx, sy, sz, nc, md, tk, maps);
 	t2 = timestamp();
 	debug_printf(DP_INFO, "\tE:   %f seconds.\n", t2 - t1);
 
 	t1 = timestamp();
-	const struct linop_s* R   = linop_reshape_create(wx, sx, sy, sz, nc, tk);
+	const struct linop_s* R = linop_reshape_create(wx, sx, sy, sz, nc, tk);
 	t2 = timestamp();
 	debug_printf(DP_INFO, "\tR:   %f seconds.\n", t2 - t1);
 
 	t1 = timestamp();
-	const struct linop_s* Fx  = linop_fx_create(wx, sy, sz, nc, tk, false);
+	const struct linop_s* Fx = linop_fx_create(wx, sy, sz, nc, tk, false);
 	t2 = timestamp();
 	debug_printf(DP_INFO, "\tFx:  %f seconds.\n", t2 - t1);
 
 	t1 = timestamp();
-	const struct linop_s* W   = linop_wave_create(wx, sy, sz, nc, tk, wave);
+	const struct linop_s* W = linop_wave_create(wx, sy, sz, nc, tk, wave);
 	t2 = timestamp();
 	debug_printf(DP_INFO, "\tW:   %f seconds.\n", t2 - t1);
 
@@ -750,7 +750,7 @@ int main_wshfl(int argc, char* argv[])
 	debug_printf(DP_INFO, "\tFyz: %f seconds.\n", t2 - t1);
 
 	t1 = timestamp();
-	const struct linop_s* K   = linop_kern_create(gpun >= 0, reorder_dims, reorder, phi_dims, phi, kernel_dims, kernel, table_dims);
+	const struct linop_s* K = linop_kern_create(gpun >= 0, reorder_dims, reorder, phi_dims, phi, kernel_dims, kernel, table_dims);
 	t2 = timestamp();
 	debug_printf(DP_INFO, "\tK:   %f seconds.\n", t2 - t1);
 

--- a/src/wshfl.c
+++ b/src/wshfl.c
@@ -467,7 +467,7 @@ static const struct linop_s* linop_reshape_create(long wx, long sx, long sy, lon
 }
 
 /* Fx operator. */
-static const struct linop_s* linop_fx_create(long wx, long sy, long sz, long nc, long tk)
+static const struct linop_s* linop_fx_create(long wx, long sy, long sz, long nc, long tk, bool centered)
 {
 	long dims[] = { [0 ... DIMS - 1] = 1};
 	dims[0] = wx;
@@ -475,7 +475,11 @@ static const struct linop_s* linop_fx_create(long wx, long sy, long sz, long nc,
 	dims[2] = sz;
 	dims[3] = nc;
 	dims[6] = tk;
-	struct linop_s* Fx = linop_fft_create(DIMS, dims, READ_FLAG);
+	struct linop_s* Fx = NULL;
+	if (centered)
+		Fx = linop_fftc_create(DIMS, dims, READ_FLAG);
+	else
+		Fx = linop_fft_create(DIMS, dims, READ_FLAG);
 	return Fx;
 }
 
@@ -493,7 +497,7 @@ static const struct linop_s* linop_wave_create(long wx, long sy, long sz, long n
 }
 
 /* Fyz operator. */
-static const struct linop_s* linop_fyz_create(long wx, long sy, long sz, long nc, long tk)
+static const struct linop_s* linop_fyz_create(long wx, long sy, long sz, long nc, long tk, bool centered)
 {
 	long dims[] = { [0 ... DIMS - 1] = 1};
 	dims[0] = wx;
@@ -501,7 +505,11 @@ static const struct linop_s* linop_fyz_create(long wx, long sy, long sz, long nc
 	dims[2] = sz;
 	dims[3] = nc;
 	dims[6] = tk;
-	struct linop_s* Fyz = linop_fft_create(DIMS, dims, PHS1_FLAG|PHS2_FLAG);
+	struct linop_s* Fyz = NULL;
+	if (centered)
+		Fyz = linop_fftc_create(DIMS, dims, PHS1_FLAG|PHS2_FLAG);
+	else
+		Fyz = linop_fft_create(DIMS, dims, PHS1_FLAG|PHS2_FLAG);
 	return Fyz;
 }
 
@@ -628,6 +636,7 @@ int main_wshfl(int argc, char* argv[])
 	float cont      = 1;
 	float eval      = -1;
 	const char* fwd = NULL;
+	const char* x0  = NULL;
 	int   gpun      = -1;
 	bool  rvc       = false;
 
@@ -640,6 +649,7 @@ int main_wshfl(int argc, char* argv[])
 		OPT_FLOAT( 't', &tol,     "toler",  "Tolerance convergence condition for iterative method."),
 		OPT_FLOAT( 'e', &eval,    "eigvl",  "Maximum eigenvalue of normal operator, if known."),
 		OPT_STRING('F', &fwd,     "frwrd",  "Go from shfl-coeffs to data-table. Pass in coeffs path."),
+		OPT_STRING('O', &x0,      "initl",  "Initialize reconstruction with guess."),
 		OPT_INT(   'g', &gpun,    "gpunm",  "GPU device number."),
 		OPT_SET(   'f', &fista,             "Reconstruct using FISTA instead of IST."),
 		OPT_SET(   'H', &hgwld,             "Use hogwild in IST/FISTA."),
@@ -710,14 +720,50 @@ int main_wshfl(int argc, char* argv[])
 	coeff_dims[4] = md;
 	coeff_dims[6] = tk;
 
-	debug_printf(DP_INFO, "Linear operator.\n");
+	debug_printf(DP_INFO, "Creating linear operators... ");
 	const struct linop_s* E   = linop_espirit_create(sx, sy, sz, nc, md, tk, maps);
 	const struct linop_s* R   = linop_reshape_create(wx, sx, sy, sz, nc, tk);
-	const struct linop_s* Fx  = linop_fx_create(wx, sy, sz, nc, tk);
+	const struct linop_s* Fx  = linop_fx_create(wx, sy, sz, nc, tk, false);
 	const struct linop_s* W   = linop_wave_create(wx, sy, sz, nc, tk, wave);
-	const struct linop_s* Fyz = linop_fyz_create(wx, sy, sz, nc, tk);
+	const struct linop_s* Fyz = linop_fyz_create(wx, sy, sz, nc, tk, false);
 	const struct linop_s* K   = linop_kern_create(gpun >= 0, reorder_dims, reorder, phi_dims, phi, kernel_dims, kernel, table_dims);
+	debug_printf(DP_INFO, "Done.\n");
 
+	if (fwd != NULL) {
+
+		debug_printf(DP_INFO, "Going from coefficients to data table... ");
+		complex float* coeffs_to_fwd = load_cfl(fwd, DIMS, coeff_dims);
+		complex float* table_forward = create_cfl(argv[6], DIMS, table_dims);
+		const struct linop_s* CFx    = linop_fx_create( wx, sy, sz, nc, tk, true);
+		const struct linop_s* CFyz   = linop_fyz_create(wx, sy, sz, nc, tk, true);
+		struct linop_s* AC = linop_chain(linop_chain(linop_chain(linop_chain(linop_chain(
+			E, R), CFx), W), CFyz), K);
+		operator_apply(AC->forward, DIMS, table_dims, table_forward, DIMS, coeff_dims, coeffs_to_fwd);
+		debug_printf(DP_INFO, "Done.\n");
+
+		debug_printf(DP_INFO, "Cleaning up... ");
+		linop_free(E);
+		linop_free(R);
+		linop_free(Fx);
+		linop_free(CFx);
+		linop_free(W);
+		linop_free(Fyz);
+		linop_free(CFyz);
+		linop_free(K);
+		linop_free(AC);
+		md_free(kernel);
+		unmap_cfl(DIMS, maps_dims, maps);
+		unmap_cfl(DIMS, wave_dims, wave);
+		unmap_cfl(DIMS, phi_dims, phi);
+		unmap_cfl(DIMS, reorder_dims, reorder);
+		unmap_cfl(DIMS, table_dims, table);
+		unmap_cfl(DIMS, table_dims, table_forward);
+		debug_printf(DP_INFO, "Done.\n");
+
+		return 0;
+	}
+
+	debug_printf(DP_INFO, "Forward linear operator information:\n");
 	struct linop_s* A = linop_chain(linop_chain(linop_chain(linop_chain(linop_chain(
 		E, R), Fx), W), Fyz), K);
 
@@ -741,16 +787,6 @@ int main_wshfl(int argc, char* argv[])
 
 	print_opdims(A);
 
-	if (fwd != NULL) {
-		debug_printf(DP_INFO, "Going from coefficients to data table... ");
-		complex float* coeffs_to_fwd = load_cfl(fwd, DIMS, coeff_dims);
-		complex float* table_forward = create_cfl(argv[6], DIMS, table_dims);
-		operator_apply(A->forward, DIMS, table_dims, table_forward, DIMS, coeff_dims, coeffs_to_fwd);
-		unmap_cfl(DIMS, table_dims, table_forward);
-		debug_printf(DP_INFO, "Done. Output table not normalized and not centered for fft.\n");
-		return 0;
-	}
-
 	if (eval < 0)	
 #ifdef USE_CUDA
 		eval = (gpun >= 0) ? estimate_maxeigenval_gpu(A->normal) : estimate_maxeigenval(A->normal);
@@ -760,7 +796,7 @@ int main_wshfl(int argc, char* argv[])
 	debug_printf(DP_INFO, "\tMax eval: %.2e\n", eval);
 	step /= eval;
 
-	debug_printf(DP_INFO, "Normalizing data table and applying fftmod to table... ");
+	debug_printf(DP_INFO, "Normalizing data table and applying fftmod to table and maps... ");
 	float norm = md_znorm(DIMS, table_dims, table);
 	md_zsmul(DIMS, table_dims, table, table, 1. / norm);
 	fftmod_apply(sy, sz, reorder_dims, reorder, table_dims, table, maps_dims, maps);
@@ -862,11 +898,18 @@ int main_wshfl(int argc, char* argv[])
 
 	}
 
+	complex float* init = NULL;
+	if (x0 != NULL) {
+		debug_printf(DP_INFO, "Loading in initial guess... ");
+		init = load_cfl(x0, DIMS, coeff_dims);
+		debug_printf(DP_INFO, "Done.\n");
+	}
+
 	debug_printf(DP_INFO, "Reconstruction... ");
 	complex float* recon = create_cfl(argv[6], DIMS, coeff_dims);
 	struct lsqr_conf lsqr_conf = { 0., gpun >= 0 };
 	double recon_start = timestamp();
-	const struct operator_s* J = lsqr2_create(&lsqr_conf, italgo, iconf, NULL, A, NULL, 1, &T, NULL, NULL);
+	const struct operator_s* J = lsqr2_create(&lsqr_conf, italgo, iconf, (const float*) init, A, NULL, 1, &T, NULL, NULL);
 	operator_apply(J, DIMS, coeff_dims, recon, DIMS, table_dims, table);
 	double recon_end = timestamp();
 	debug_printf(DP_INFO, "Done.\nReconstruction time: %f seconds.\n", recon_end - recon_start);
@@ -881,6 +924,8 @@ int main_wshfl(int argc, char* argv[])
 	unmap_cfl(DIMS, reorder_dims, reorder);
 	unmap_cfl(DIMS, table_dims, table);
 	unmap_cfl(DIMS, coeff_dims, recon);
+	if (x0 != NULL)
+		unmap_cfl(DIMS, coeff_dims, init);
 	debug_printf(DP_INFO, "Done.\n");
 
 	double end_time = timestamp();

--- a/tests/wave.mk
+++ b/tests/wave.mk
@@ -6,7 +6,7 @@ tests/test-wave: wave wavepsf scale nrmse $(TESTS_OUT)/shepplogan.ra $(TESTS_OUT
 	$(TOOLDIR)/fft -u 1 wave_zpad.ra wave_hyb.ra                          ;\
 	$(TOOLDIR)/fmac wave_hyb.ra wave_psf.ra wave_acq.ra                   ;\
 	$(TOOLDIR)/fft -u 6 wave_acq.ra wave_ksp.ra                           ;\
-	$(TOOLDIR)/wave wave_ksp.ra $(TESTS_OUT)/coils.ra wave_psf.ra reco.ra ;\
+	$(TOOLDIR)/wave $(TESTS_OUT)/coils.ra wave_psf.ra wave_ksp.ra reco.ra ;\
 	$(TOOLDIR)/nrmse -t 0.23 -s reco.ra $(TESTS_OUT)/shepplogan.ra        ;\
 	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
 	touch $@


### PR DESCRIPTION
**FFTW Wisdom**:
- If `TOOLBOX_PATH` is set, `fft_fftwf_plan` will check to see if `fftw_plan` has been carried out previously for dimensions that exactly match the input's dimensions.
- If there is a match, `fftw_import` is called to load the previous plan's "wisdom" to warm start the current plan calculation. If there is no match, proceed normally.
- After calculating a plan, it is saved for future use. Plans located at `save/fftw/`.

_Comment_: I made this change because creating the plan took around 30 minutes for `wave` and `wshfl`. This drops the `linop_create` time drastically for both cases.

**wshfl**:
- Linear operator timings.
- Cosmetic changes.

**wave**:
- Modified to be similar to `wshfl`.