### PR TITLE
add lz when LINKER=icc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,6 +331,10 @@ ifeq ($(SLINK),1)
 	PNG_L += -lz
 endif
 
+ifeq ($(LINKER),icc)
+	PNG_L += -lz
+endif
+
 
 
 # fftw


### PR DESCRIPTION
Fixes compile error when using icc for linking