### PR TITLE
src/slice.c: extend to allow multiple dims and pos

### DIFF
--- a/tests/slice.mk
+++ b/tests/slice.mk
@@ -10,6 +10,14 @@ tests/test-slice: ones slice resize nrmse
 	touch $@
 
 
+tests/test-slice-multidim: ones slice resize nrmse
+	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)						;\
+	$(TOOLDIR)/ones 3 1 1 1 o.ra								;\
+	$(TOOLDIR)/resize -c 0 100 1 100 2 100 o.ra o0.ra						;\
+	$(TOOLDIR)/slice 0 50 1 50 2 50 o0.ra o1.ra							;\
+	$(TOOLDIR)/nrmse -t 0. o1.ra o.ra							;\
+	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
+	touch $@
 
-TESTS += tests/test-slice
+TESTS += tests/test-slice tests/test-slice-multidim
 


### PR DESCRIPTION
Similar to resize, slice now accepts an arbitrary number of dims and
positions.

I am not sure if there is a cleaner way than the empty opts array.