### PR TITLE
src/extract.c: add test and extend to multiple dims

### DIFF
--- a/src/extract.c
+++ b/src/extract.c
@@ -19,7 +19,13 @@
 #include "misc/misc.h"
 
 
+#ifndef DIMS
 #define DIMS 16
+#endif
+
+#ifndef CFL_SIZE
+#define CFL_SIZE sizeof(complex float)
+#endif
 
 static const char usage_str[] = "dimension start end <input> <output>";
 static const char help_str[] = "Extracts a sub-array along {dim} from index {start} to (not including) {end}.\n";
@@ -55,7 +61,7 @@ int main_extract(int argc, char* argv[])
 	long pos2[DIMS] = { [0 ... DIMS - 1] = 0 };
 	pos2[dim] = start;
 	
-	md_copy_block(DIMS, pos2, out_dims, out_data, in_dims, in_data, sizeof(complex float));
+	md_copy_block(DIMS, pos2, out_dims, out_data, in_dims, in_data, CFL_SIZE);
 
 	unmap_cfl(DIMS, in_dims, in_data);
 	unmap_cfl(DIMS, out_dims, out_data);

--- a/src/extract.c
+++ b/src/extract.c
@@ -17,6 +17,7 @@
 
 #include "misc/mmio.h"
 #include "misc/misc.h"
+#include "misc/opts.h"
 
 
 #ifndef DIMS
@@ -27,40 +28,48 @@
 #define CFL_SIZE sizeof(complex float)
 #endif
 
-static const char usage_str[] = "dimension start end <input> <output>";
-static const char help_str[] = "Extracts a sub-array along {dim} from index {start} to (not including) {end}.\n";
+static const char usage_str[] = "dim1 start1 end1 ... dimn startn endn <input> <output>";
+static const char help_str[] = "Extracts a sub-array along dims from index start to (not including) end.\n";
 
 
 int main_extract(int argc, char* argv[])
 {
-	mini_cmdline(&argc, argv, 5, usage_str, help_str);
+	const struct opt_s opts[] = {};
+
+	cmdline(&argc, argv, 5, 1000, usage_str, help_str, ARRAY_SIZE(opts), opts);
 
 	num_init();
 
 	long in_dims[DIMS];
 	long out_dims[DIMS];
 	
-	complex float* in_data = load_cfl(argv[4], DIMS, in_dims);
+	complex float* in_data = load_cfl(argv[argc - 2], DIMS, in_dims);
+	md_copy_dims(DIMS, out_dims, in_dims);
 
-	int dim = atoi(argv[1]);
-	int start = atoi(argv[2]);
-	int end = atoi(argv[3]);
+	int count = argc - 3;
+	assert((count > 0) && (count % 3 == 0));
 
-	assert((0 <= dim) && (dim < DIMS));
-	assert(start >= 0);
-	assert(start < end);
-	assert(end <= in_dims[dim]);
-
-	for (int i = 0; i < DIMS; i++)
-		out_dims[i] = in_dims[i];
-
-	out_dims[dim] = end - start;
-
-	complex float* out_data = create_cfl(argv[5], DIMS, out_dims);
 
 	long pos2[DIMS] = { [0 ... DIMS - 1] = 0 };
-	pos2[dim] = start;
-	
+
+	for (int i = 0; i < count; i += 3) {
+
+		int dim = atoi(argv[i + 1]);
+		int start = atoi(argv[i + 2]);
+		int end = atoi(argv[i + 3]);
+
+		assert((0 <= dim) && (dim < DIMS));
+		assert(start >= 0);
+		assert(start < end);
+		assert(end <= in_dims[dim]);
+
+		out_dims[dim] = end - start;
+		pos2[dim] = start;
+	}
+
+
+	complex float* out_data = create_cfl(argv[argc - 1], DIMS, out_dims);
+
 	md_copy_block(DIMS, pos2, out_dims, out_data, in_dims, in_data, CFL_SIZE);
 
 	unmap_cfl(DIMS, in_dims, in_data);

--- a/tests/extract.mk
+++ b/tests/extract.mk
@@ -1,0 +1,23 @@
+
+tests/test-extract: ones extract resize nrmse
+	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)						;\
+	$(TOOLDIR)/ones 2 10 10 o.ra								;\
+	$(TOOLDIR)/resize -c 0 100 1 100 o.ra o0.ra						;\
+	$(TOOLDIR)/extract 1 45 55 o0.ra o1.ra							;\
+	$(TOOLDIR)/extract 0 45 55 o1.ra o2.ra							;\
+	$(TOOLDIR)/nrmse -t 0. o2.ra o.ra							;\
+	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
+	touch $@
+
+
+tests/test-extract-multidim: ones extract resize nrmse
+	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)						;\
+	$(TOOLDIR)/ones 3 10 10 10 o.ra								;\
+	$(TOOLDIR)/resize -c 0 100 1 100 2 100 o.ra o0.ra						;\
+	$(TOOLDIR)/extract 0 45 55 1 45 55 2 45 55 o0.ra o1.ra							;\
+	$(TOOLDIR)/nrmse -t 0. o1.ra o.ra							;\
+	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
+	touch $@
+
+TESTS += tests/test-extract tests/test-extract-multidim
+


### PR DESCRIPTION
Similar to resize and slice, extract now accepts an
arbitrary number of dims and positions (starts and ends).


Sorry, this really should have been together with the last pull request.