### PR TITLE
Line search in sure crop + stricter test for auto-espirit

### DIFF
--- a/tests/ecalib.mk
+++ b/tests/ecalib.mk
@@ -14,7 +14,7 @@ tests/test-ecalib-auto: ecalib pocsense nrmse noise $(TESTS_OUT)/shepplogan_coil
 	$(TOOLDIR)/noise -n 100 $(TESTS_OUT)/shepplogan_coil_ksp.ra shepplogan_noise.ra ;\
 	$(TOOLDIR)/ecalib -m 1 -a -v 100 shepplogan_noise.ra coils.ra ;\
 	$(TOOLDIR)/pocsense -i 1 shepplogan_noise.ra coils.ra proj.ra ;\
-	$(TOOLDIR)/nrmse -t 0.05 proj.ra $(TESTS_OUT)/shepplogan_coil_ksp.ra ;\
+	$(TOOLDIR)/nrmse -t 0.035 $(TESTS_OUT)/shepplogan_coil_ksp.ra proj.ra;\
 	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
 	touch $@
 


### PR DESCRIPTION
I am really sorry for the additional pull request. I came across several edge cases with the old implementation that made me switch to a much simpler line search based method for sure_crop. The new implementation also prints the expected MSE as a function of the crop threshold as a sanity check. Additionally, I made the auto-espirit test stricter as a code change broke my 2016 implementation but it was not caught by the test.