### PR TITLE
Modify wshfl to apply ESPIRiT channel-by-channel.

### DIFF
--- a/src/wshfl.c
+++ b/src/wshfl.c
@@ -381,8 +381,6 @@ static const struct linop_s* linop_kern_create(bool gpu_flag,
 	PTR_ALLOC(struct kern_s, data);
 	SET_TYPEID(kern_s, data);
 
-	data->N = DIMS;
-
 	PTR_ALLOC(long[DIMS], reorder_dims);
 	PTR_ALLOC(long[DIMS], phi_dims);
 	PTR_ALLOC(long[DIMS], table_dims);
@@ -443,19 +441,266 @@ static const struct linop_s* linop_kern_create(bool gpu_flag,
 	return K;
 }
 
-/* ESPIRiT operator. */
-static const struct linop_s* linop_espirit_create(long sx, long sy, long sz, long nc, long md, long tk, complex float* maps)
-{
-	long max_dims[] = { [0 ... DIMS - 1] = 1};
-	max_dims[0] = sx;
-	max_dims[1] = sy;
-	max_dims[2] = sz;
-	max_dims[3] = nc;
-	max_dims[4] = md;
-	max_dims[6] = tk;
+struct multc_s {
+	INTERFACE(linop_data_t);
 
-	const struct linop_s* E = linop_fmac_create(DIMS, max_dims, MAPS_FLAG, COIL_FLAG, TE_FLAG|COEFF_FLAG, maps);
- 
+	unsigned int nc;
+	unsigned int md;
+	const complex float* maps;
+	const struct linop_s* sc_op; // Single channel operator.
+};
+
+static DEF_TYPEID(multc_s);
+
+static void multc_apply(const linop_data_t* _data, complex float* dst, const complex float* src)
+{
+	const struct multc_s* data = CAST_DOWN(multc_s, _data);
+
+	// Loading single channel operator.
+	const struct operator_s* fwd = data->sc_op->forward;
+	const long* sc_inp_dims = linop_domain(data->sc_op)->dims;
+	const long* sc_out_dims = linop_codomain(data->sc_op)->dims;
+
+	long sx = sc_inp_dims[0];
+	long sy = sc_inp_dims[1];
+	long sz = sc_inp_dims[2];
+	long wx = sc_out_dims[0];
+	long  n = sc_out_dims[2];
+	long nc = data->nc;
+	long md = data->md;
+
+	long src_dims[] = { [0 ... DIMS - 1] = 1};
+	md_copy_dims(DIMS, src_dims, sc_inp_dims);
+	src_dims[MAPS_DIM] = md;
+
+	long dst_dims[] = { [0 ... DIMS - 1] = 1};
+	md_copy_dims(DIMS, dst_dims, sc_out_dims);
+	dst_dims[1] = nc;
+
+	long map_dims[] = { [0 ... DIMS - 1] = 1};
+	map_dims[0] = sx;
+	map_dims[1] = sy;
+	map_dims[2] = sz;
+	map_dims[3] = nc;
+	map_dims[4] = md;
+
+	long single_map_dims[] = { [0 ... DIMS - 1] = 1 };
+	md_copy_dims(DIMS, single_map_dims, map_dims);
+	single_map_dims[COIL_DIM] = 1;
+	complex float* single_map = md_alloc_sameplace(DIMS, single_map_dims, CFL_SIZE, src);
+
+	complex float* buffer = md_alloc_sameplace(DIMS, sc_inp_dims, CFL_SIZE, src);
+
+	long tbl_dims[] = { [0 ... DIMS - 1] = 1};
+	tbl_dims[0] = wx;
+	tbl_dims[1] = n;
+	tbl_dims[2] = nc;
+	complex float* tbl = md_alloc_sameplace(DIMS, tbl_dims, CFL_SIZE, src);
+	md_clear(DIMS, tbl_dims, tbl, CFL_SIZE);
+
+	long pos[] = { [0 ... DIMS - 1] = 0 };
+
+	long zfmac_dims[] = { [0 ... DIMS - 1] = 1 };
+	md_copy_dims(DIMS, zfmac_dims, src_dims);
+
+	long strides_single_map[DIMS];
+	md_calc_strides(DIMS, strides_single_map, single_map_dims, CFL_SIZE);
+	long strides_src[DIMS];
+	md_calc_strides(DIMS, strides_src, src_dims, CFL_SIZE);
+	long strides_sc_inp[DIMS];
+	md_calc_strides(DIMS, strides_sc_inp, sc_inp_dims, CFL_SIZE);
+
+	for (long k = 0; k < data->nc; k++) {
+		md_clear(DIMS, single_map_dims, single_map, CFL_SIZE);
+		md_clear(DIMS, sc_inp_dims, buffer, CFL_SIZE);
+		pos[COIL_DIM] = k;
+		md_slice(DIMS, COIL_FLAG, pos, map_dims, single_map, data->maps, CFL_SIZE);
+		pos[COIL_DIM] = 0;
+		md_zfmac2(DIMS, zfmac_dims, strides_sc_inp, buffer, strides_src, src, strides_single_map, single_map);
+		operator_apply(fwd, DIMS, sc_out_dims, tbl  + (wx * n * k), DIMS, sc_inp_dims, buffer);
+	}
+
+	md_clear(DIMS, dst_dims, dst, CFL_SIZE);
+	unsigned int permute_order[DIMS] = {0, 2, 1};
+	for (unsigned int i = 3; i < DIMS; i++)
+		permute_order[i] = i;
+	md_permute(DIMS, permute_order, dst_dims, dst, tbl_dims, tbl, CFL_SIZE);
+
+	md_free(single_map);
+	md_free(buffer);
+	md_free(tbl);
+}
+
+static void multc_adjoint(const linop_data_t* _data, complex float* dst, const complex float* src)
+{
+	const struct multc_s* data = CAST_DOWN(multc_s, _data);
+
+	// Loading single channel operator.
+	const struct operator_s* adj = data->sc_op->adjoint;
+	const long* sc_inp_dims = linop_codomain(data->sc_op)->dims;
+	const long* sc_out_dims = linop_domain(data->sc_op)->dims;
+
+	long sx = sc_out_dims[0];
+	long sy = sc_out_dims[1];
+	long sz = sc_out_dims[2];
+	long wx = sc_inp_dims[0];
+	long  n = sc_inp_dims[2];
+	long nc = data->nc;
+	long md = data->md;
+
+	long src_dims[] = { [0 ... DIMS - 1] = 1};
+	md_copy_dims(DIMS, src_dims, sc_inp_dims);
+	src_dims[1] = nc;
+
+	long dst_dims[] = { [0 ... DIMS - 1] = 1};
+	md_copy_dims(DIMS, dst_dims, sc_out_dims);
+	src_dims[MAPS_DIM] = md;
+
+	long map_dims[] = { [0 ... DIMS - 1] = 1};
+	map_dims[0] = sx;
+	map_dims[1] = sy;
+	map_dims[2] = sz;
+	map_dims[3] = nc;
+	map_dims[4] = md;
+
+	long single_map_dims[] = { [0 ... DIMS - 1] = 1 };
+	md_copy_dims(DIMS, single_map_dims, map_dims);
+	single_map_dims[COIL_DIM] = 1;
+	complex float* single_map = md_alloc_sameplace(DIMS, single_map_dims, CFL_SIZE, src);
+
+	complex float* buffer1 = md_alloc_sameplace(DIMS, sc_out_dims, CFL_SIZE, src);
+	complex float* buffer2 = md_alloc_sameplace(DIMS, dst_dims, CFL_SIZE, src);
+
+	long tbl_dims[] = { [0 ... DIMS - 1] = 1};
+	tbl_dims[0] = wx;
+	tbl_dims[2] = n;
+	complex float* tbl = md_alloc_sameplace(DIMS, tbl_dims, CFL_SIZE, src);
+
+	long pos[] = { [0 ... DIMS - 1] = 0 };
+
+	long strides_single_map[DIMS];
+	md_calc_strides(DIMS, strides_single_map, single_map_dims, CFL_SIZE);
+	long strides_sc_out[DIMS];
+	md_calc_strides(DIMS, strides_sc_out, sc_out_dims, CFL_SIZE);
+	long strides_dst[DIMS];
+	md_calc_strides(DIMS, strides_dst, dst_dims, CFL_SIZE);
+
+	md_clear(DIMS, dst_dims, dst, CFL_SIZE);
+	
+	for (long k = 0; k < data->nc; k++) {
+		md_clear(DIMS, single_map_dims, single_map, CFL_SIZE);
+		md_clear(DIMS, sc_out_dims, buffer1, CFL_SIZE);
+		md_clear(DIMS, dst_dims, buffer2, CFL_SIZE);
+		md_clear(DIMS, tbl_dims, tbl, CFL_SIZE);
+		pos[1] = k;
+		md_slice(DIMS, 2, pos, src_dims, tbl, src, CFL_SIZE);
+		pos[1] = 0;
+		operator_apply(adj, DIMS, sc_out_dims, buffer1, DIMS, tbl_dims, tbl);
+		pos[COIL_DIM] = k;
+		md_slice(DIMS, COIL_FLAG, pos, map_dims, single_map, data->maps, CFL_SIZE);
+		pos[COIL_DIM] = 0;
+		md_zfmacc2(DIMS, dst_dims, strides_dst, buffer2, strides_sc_out, buffer1, strides_single_map, single_map);
+		md_zadd(DIMS, dst_dims, dst, dst, buffer2);
+	}
+
+	md_free(single_map);
+	md_free(buffer1);
+	md_free(buffer2);
+	md_free(tbl);
+}
+
+static void multc_normal(const linop_data_t* _data, complex float* dst, const complex float* src)
+{
+	const struct multc_s* data = CAST_DOWN(multc_s, _data);
+
+	// Loading single channel operator.
+	const struct operator_s* nrm = data->sc_op->normal;
+	const long* sc_dims = linop_domain(data->sc_op)->dims;
+
+	long sx = sc_dims[0];
+	long sy = sc_dims[1];
+	long sz = sc_dims[2];
+	long nc = data->nc;
+	long md = data->md;
+
+	long dims[] = { [0 ... DIMS - 1] = 1};
+	md_copy_dims(DIMS, dims, sc_dims);
+	dims[MAPS_DIM] = md;
+
+	long map_dims[] = { [0 ... DIMS - 1] = 1};
+	map_dims[0] = sx;
+	map_dims[1] = sy;
+	map_dims[2] = sz;
+	map_dims[3] = nc;
+	map_dims[4] = md;
+
+	long single_map_dims[] = { [0 ... DIMS - 1] = 1 };
+	md_copy_dims(DIMS, single_map_dims, map_dims);
+	single_map_dims[COIL_DIM] = 1;
+	complex float* single_map = md_alloc_sameplace(DIMS, single_map_dims, CFL_SIZE, src);
+
+	complex float* buffer1 = md_alloc_sameplace(DIMS, sc_dims, CFL_SIZE, src);
+	complex float* buffer2 = md_alloc_sameplace(DIMS, sc_dims, CFL_SIZE, src);
+	complex float* buffer3 = md_alloc_sameplace(DIMS, dims, CFL_SIZE, src);
+
+	long pos[] = { [0 ... DIMS - 1] = 0 };
+
+	long strides_single_map[DIMS];
+	md_calc_strides(DIMS, strides_single_map, single_map_dims, CFL_SIZE);
+	long strides_sc[DIMS];
+	md_calc_strides(DIMS, strides_sc, sc_dims, CFL_SIZE);
+	long strides[DIMS];
+	md_calc_strides(DIMS, strides, dims, CFL_SIZE);
+
+	md_clear(DIMS, dims, dst, CFL_SIZE);
+	for (long k = 0; k < data->nc; k++) {
+		md_clear(DIMS, single_map_dims, single_map, CFL_SIZE);
+		md_clear(DIMS, sc_dims, buffer1, CFL_SIZE);
+		md_clear(DIMS, sc_dims, buffer2, CFL_SIZE);
+		md_clear(DIMS, dims, buffer3, CFL_SIZE);
+		pos[COIL_DIM] = k;
+		md_slice(DIMS, COIL_FLAG, pos, map_dims, single_map, data->maps, CFL_SIZE);
+		pos[COIL_DIM] = 0;
+		md_zfmac2(DIMS, dims, strides_sc, buffer1, strides, src, strides_single_map, single_map);
+		operator_apply(nrm, DIMS, sc_dims, buffer2, DIMS, sc_dims, buffer1);
+		md_zfmacc2(DIMS, dims, strides, buffer3, strides_sc, buffer2, strides_single_map, single_map);
+		md_zadd(DIMS, dims, dst, dst, buffer3);
+	}
+
+	md_free(single_map);
+	md_free(buffer1);
+	md_free(buffer2);
+	md_free(buffer3);
+}
+
+static void multc_free(const linop_data_t* _data)
+{
+	const struct multc_s* data = CAST_DOWN(multc_s, _data);
+	xfree(data);
+}
+
+static struct linop_s* linop_multc_create(long nc, long md, const complex float* maps, const struct linop_s* sc_op)
+{
+	PTR_ALLOC(struct multc_s, data);
+	SET_TYPEID(multc_s, data);
+
+	data->nc = nc;
+	data->md = md;
+	data->maps = maps;
+	data->sc_op = sc_op;
+
+	long* op_inp_dims = (long*) linop_domain(sc_op)->dims;
+	long* op_out_dims = (long*) linop_codomain(sc_op)->dims;
+
+	long input_dims[] = { [0 ... DIMS - 1] = 1 };
+	md_copy_dims(DIMS, input_dims, op_inp_dims);
+	input_dims[MAPS_DIM] = md;
+
+	long output_dims[] = { [0 ... DIMS - 1] = 1 };
+	md_copy_dims(DIMS, output_dims, op_out_dims);
+	output_dims[1] = nc;
+
+	struct linop_s* E = linop_create(DIMS, output_dims, DIMS, input_dims, CAST_UP(PTR_PASS(data)), multc_apply, multc_adjoint, multc_normal, NULL, multc_free);
 	return E;
 }
 
@@ -735,57 +980,76 @@ int main_wshfl(int argc, char* argv[])
 	coeff_dims[6] = tk;
 	coeff_dims[8] = dcx ? 2 : 1;
 
-	debug_printf(DP_INFO, "Creating linear operators:\n");
+	debug_printf(DP_INFO, "Creating single channel linear operators:\n");
 
 	double t1;
 	double t2;
 
 	t1 = timestamp();
-	const struct linop_s* E = linop_espirit_create(sx, sy, sz, nc, md, tk, maps);
-	t2 = timestamp();
-	debug_printf(DP_INFO, "\tE:   %f seconds.\n", t2 - t1);
-
-	t1 = timestamp();
-	const struct linop_s* R = linop_wavereshape_create(wx, sx, sy, sz, nc, tk);
+	const struct linop_s* R = linop_wavereshape_create(wx, sx, sy, sz, 1, tk);
 	t2 = timestamp();
 	debug_printf(DP_INFO, "\tR:   %f seconds.\n", t2 - t1);
 
 	t1 = timestamp();
-	const struct linop_s* Fx = linop_fx_create(wx, sy, sz, nc, tk, false);
+	const struct linop_s* Fx = linop_fx_create(wx, sy, sz, 1, tk, false);
 	t2 = timestamp();
 	debug_printf(DP_INFO, "\tFx:  %f seconds.\n", t2 - t1);
 
 	t1 = timestamp();
-	const struct linop_s* W = linop_wave_create(wx, sy, sz, nc, tk, wave);
+	const struct linop_s* W = linop_wave_create(wx, sy, sz, 1, tk, wave);
 	t2 = timestamp();
 	debug_printf(DP_INFO, "\tW:   %f seconds.\n", t2 - t1);
 
 	t1 = timestamp();
-	const struct linop_s* Fyz = linop_fyz_create(wx, sy, sz, nc, tk, false);
+	const struct linop_s* Fyz = linop_fyz_create(wx, sy, sz, 1, tk, false);
 	t2 = timestamp();
 	debug_printf(DP_INFO, "\tFyz: %f seconds.\n", t2 - t1);
 
 	t1 = timestamp();
-	const struct linop_s* K = linop_kern_create(gpun >= 0, reorder_dims, reorder, phi_dims, phi, kernel_dims, kernel, table_dims);
+	long single_channel_table_dims[] = { [0 ... DIMS - 1] = 1 };
+	md_copy_dims(DIMS, single_channel_table_dims, table_dims);
+	single_channel_table_dims[1] = 1;
+	const struct linop_s* K = linop_kern_create(gpun >= 0, reorder_dims, reorder, phi_dims, phi, kernel_dims, kernel, single_channel_table_dims);
 	t2 = timestamp();
 	debug_printf(DP_INFO, "\tK:   %f seconds.\n", t2 - t1);
+
+	struct linop_s* A_sc = linop_chain_FF(linop_chain_FF(linop_chain_FF(linop_chain_FF(
+		R, Fx), W), Fyz), K);
+
+	debug_printf(DP_INFO, "Single channel forward operator information:\n");
+	print_opdims(A_sc);
+	if (eval < 0)	
+#ifdef USE_CUDA
+		eval = (gpun >= 0) ? estimate_maxeigenval_gpu(A_sc->normal) : estimate_maxeigenval(A_sc->normal);
+#else
+		eval = estimate_maxeigenval(A_sc->normal);
+#endif
+	debug_printf(DP_INFO, "\tMax eval: %.2e\n", eval);
+	step /= eval;
+
+	struct linop_s* A = linop_multc_create(nc, md, maps, A_sc);
+	debug_printf(DP_INFO, "Overall forward linear operator information:\n");
+	print_opdims(A);
 
 	if (fwd != NULL) {
 
 		debug_printf(DP_INFO, "Going from coefficients to data table... ");
 		complex float* coeffs_to_fwd = load_cfl(fwd, DIMS, coeff_dims);
 		complex float* table_forward = create_cfl(argv[6], DIMS, table_dims);
-		const struct linop_s* CFx    = linop_fx_create( wx, sy, sz, nc, tk, true);
-		const struct linop_s* CFyz   = linop_fyz_create(wx, sy, sz, nc, tk, true);
-		struct linop_s* AC = linop_chain_FF(linop_chain_FF(linop_chain_FF(linop_chain_FF(linop_chain_FF(
-			E, R), CFx), W), CFyz), K);
+		const struct linop_s* R      = linop_wavereshape_create(wx, sx, sy, sz, 1, tk);
+		const struct linop_s* CFx    = linop_fx_create( wx, sy, sz, 1, tk, true);
+		const struct linop_s* W      = linop_wave_create(wx, sy, sz, 1, tk, wave);
+		const struct linop_s* CFyz   = linop_fyz_create(wx, sy, sz, 1, tk, true);
+		const struct linop_s* K      = linop_kern_create(gpun >= 0, reorder_dims, reorder, phi_dims, phi, kernel_dims, kernel, single_channel_table_dims);
+		struct linop_s* AC_sc = linop_chain_FF(linop_chain_FF(linop_chain_FF(linop_chain_FF(
+			R, CFx), W), CFyz), K);
+		struct linop_s* AC = linop_multc_create(nc, md, maps, AC_sc);
 		operator_apply(AC->forward, DIMS, table_dims, table_forward, DIMS, coeff_dims, coeffs_to_fwd);
 		debug_printf(DP_INFO, "Done.\n");
 
 		debug_printf(DP_INFO, "Cleaning up... ");
-		linop_free(Fx);
-		linop_free(CFyz);
 		linop_free(AC);
+		linop_free(AC_sc);
 		md_free(kernel);
 		unmap_cfl(DIMS, maps_dims, maps);
 		unmap_cfl(DIMS, wave_dims, wave);
@@ -798,10 +1062,6 @@ int main_wshfl(int argc, char* argv[])
 		return 0;
 	}
 
-	debug_printf(DP_INFO, "Forward linear operator information:\n");
-	struct linop_s* A = linop_chain_FF(linop_chain_FF(linop_chain_FF(linop_chain_FF(linop_chain_FF(
-		E, R), Fx), W), Fyz), K);
-
 	if (dcx) {
 		debug_printf(DP_INFO, "\tSplitting result into real and imaginary components.\n");
 		struct linop_s* tmp = A;
@@ -812,17 +1072,6 @@ int main_wshfl(int argc, char* argv[])
 		linop_free(dcxop);
 		linop_free(tmp);
 	}
-
-	print_opdims(A);
-
-	if (eval < 0)	
-#ifdef USE_CUDA
-		eval = (gpun >= 0) ? estimate_maxeigenval_gpu(A->normal) : estimate_maxeigenval(A->normal);
-#else
-		eval = estimate_maxeigenval(A->normal);
-#endif
-	debug_printf(DP_INFO, "\tMax eval: %.2e\n", eval);
-	step /= eval;
 
 	debug_printf(DP_INFO, "Normalizing data table and applying fftmod to table and maps... ");
 	float norm = md_znorm(DIMS, table_dims, table);
@@ -950,6 +1199,7 @@ int main_wshfl(int argc, char* argv[])
 	debug_printf(DP_INFO, "Cleaning up and saving result... ");
 	operator_p_free(J);
 	linop_free(A);
+	linop_free(A_sc);
 	md_free(kernel);
 	unmap_cfl(DIMS, maps_dims, maps);
 	unmap_cfl(DIMS, wave_dims, wave);

--- a/src/wshfl.c
+++ b/src/wshfl.c
@@ -460,7 +460,7 @@ static const struct linop_s* linop_espirit_create(long sx, long sy, long sz, lon
 }
 
 /* Resize operator. */
-static const struct linop_s* Xlinop_reshape_create(long wx, long sx, long sy, long sz, long nc, long tk)
+static const struct linop_s* linop_wavereshape_create(long wx, long sx, long sy, long sz, long nc, long tk)
 {
 	long input_dims[] = { [0 ... DIMS - 1] = 1};
 	input_dims[0] = sx;
@@ -746,7 +746,7 @@ int main_wshfl(int argc, char* argv[])
 	debug_printf(DP_INFO, "\tE:   %f seconds.\n", t2 - t1);
 
 	t1 = timestamp();
-	const struct linop_s* R = Xlinop_reshape_create(wx, sx, sy, sz, nc, tk);
+	const struct linop_s* R = linop_wavereshape_create(wx, sx, sy, sz, nc, tk);
 	t2 = timestamp();
 	debug_printf(DP_INFO, "\tR:   %f seconds.\n", t2 - t1);
 

--- a/src/wshfl.c
+++ b/src/wshfl.c
@@ -97,10 +97,20 @@ static void print_opdims(const struct linop_s* op)
 {
 	const struct iovec_s* domain   = linop_domain(op);
 	const struct iovec_s* codomain = linop_codomain(op);
-	debug_printf(DP_INFO, "\tDomain:   ");
-	debug_print_dims(DP_INFO, domain->N, domain->dims);
-	debug_printf(DP_INFO, "\tCodomain: ");
-	debug_print_dims(DP_INFO, codomain->N, codomain->dims);
+	debug_printf(DP_INFO, "\tDomain:   [");
+	for (long k = 0; k < domain->N; k ++) {
+		for (long t = (long) floor(log10(domain->dims[k])) + 1; t < 7; t ++)
+			debug_printf(DP_INFO, " ");
+		debug_printf(DP_INFO, "%d", domain->dims[k]);
+	}
+	debug_printf(DP_INFO, "]\n");
+	debug_printf(DP_INFO, "\tCodomain: [");
+	for (long k = 0; k < codomain->N; k ++) {
+		for (long t = (long) floor(log10(codomain->dims[k])) + 1; t < 7; t ++)
+			debug_printf(DP_INFO, " ");
+		debug_printf(DP_INFO, "%d", codomain->dims[k]);
+	}
+	debug_printf(DP_INFO, "]\n");
 }
 
 /* Construct sampling mask array from reorder tables. */


### PR DESCRIPTION
All modifications applied to wshfl.  
- Implemented single-channel forward operator.
- Modified ESPIRiT linop in wshfl to apply the above single channel operator per channel.
- Allows for ESPIRiT maps to remain in CPU memory, allowing the single channel operator to work on the GPU.

On my machine, it reduces minutes per iteration from 0.82 to 0.21.