### PR TITLE
warn on (but support) identical input and output

### DIFF
--- a/src/avg.c
+++ b/src/avg.c
@@ -45,6 +45,8 @@ int main_avg(int argc, char* argv[argc])
 	long idims[N];
 	complex float* data = load_cfl(argv[2], N, idims);
 
+	copy_if_equal_in_out(argv[3], argv[2], DIMS, idims, &data, "avg");
+
 	long odims[N];
 	md_select_dims(N, ~flags, odims, idims);
 

--- a/src/bin.c
+++ b/src/bin.c
@@ -85,7 +85,7 @@ n_card, const int n_resp)
 	for (int t = 0; t < T; t++) { // Iterate all spokes of input array
 
 		pos0[TIME_DIM] = t;
-		md_copy_block(DIMS, pos0, in_singleton_dims, in_singleton, in_dims, in, CFL_SIZE);
+		md_copy_block(DIMS, pos0, in_singleton_dims, in_singleton, in_dims, &in, CFL_SIZE);
 
 		int cBin = (int)bins[0 * T + t];
 		int rBin = (int)bins[1 * T + t];
@@ -170,6 +170,9 @@ int main_bin(int argc, char* argv[])
 
 	long src_dims[DIMS];
 	complex float* src = load_cfl(argv[2], DIMS, src_dims);
+
+	if (0 == strcmp(argv[2], argv[3]))
+		error("bin cannot be called with identical input and output!\n");
 
 	enum { BIN_QUADRATURE, BIN_LABEL, BIN_REORDER } bin_type;
 

--- a/src/casorati.c
+++ b/src/casorati.c
@@ -47,6 +47,8 @@ int main_casorati(int argc, char* argv[])
 
 	complex float* idata = load_cfl(argv[argc - 2], DIMS, idims);
 
+	copy_if_equal_in_out(argv[argc - 1], argv[argc - 2], DIMS, idims, &idata, "casorati");
+
 	md_copy_dims(DIMS, kdims, idims);
 
 	for (int i = 0; i < count; i += 2) {

--- a/src/cc.c
+++ b/src/cc.c
@@ -70,6 +70,8 @@ int main_cc(int argc, char* argv[])
 
 	complex float* in_data = load_cfl(argv[1], DIMS, in_dims);
 
+	copy_if_equal_in_out(argv[2], argv[1], DIMS, in_dims, &in_data, "cc");
+
 	assert(1 == in_dims[MAPS_DIM]);
 	long channels = in_dims[COIL_DIM];
 

--- a/src/ccapply.c
+++ b/src/ccapply.c
@@ -58,6 +58,9 @@ int main_ccapply(int argc, char* argv[])
 	complex float* in_data = load_cfl(argv[1], DIMS, in_dims);
 	complex float* cc_data = load_cfl(argv[2], DIMS, cc_dims);
 
+	copy_if_equal_in_out(argv[2], argv[1], DIMS, in_dims, &in_data, "ccapply");
+
+
 	assert(1 == in_dims[MAPS_DIM]);
 	const long channels = cc_dims[COIL_DIM];
 
@@ -70,7 +73,7 @@ int main_ccapply(int argc, char* argv[])
 
 	md_select_dims(DIMS, ~COIL_FLAG, out_dims, in_dims);
 	out_dims[COIL_DIM] = forward ? P : channels;
-	
+
 	complex float* out_data = create_cfl(argv[3], DIMS, out_dims);
 
 	// transpose for the matrix multiplication

--- a/src/circshift.c
+++ b/src/circshift.c
@@ -48,6 +48,10 @@ int main_circshift(int argc, char* argv[])
 	center[dim] = shift;
 
 	complex float* idata = load_cfl(argv[3], N, dims);
+
+	copy_if_equal_in_out(argv[4], argv[3], DIMS, dims, &idata, "circshift");
+
+
 	complex float* odata = create_cfl(argv[4], N, dims);
 
 	md_circ_shift(N, dims, center, odata, idata, sizeof(complex float));

--- a/src/crop.c
+++ b/src/crop.c
@@ -39,6 +39,8 @@ int main_crop(int argc, char* argv[])
 	
 	complex float* in_data = load_cfl(argv[3], N, in_dims);
 
+	copy_if_equal_in_out(argv[4], argv[3], DIMS, in_dims, &in_data, "crop");
+
 	int dim = atoi(argv[1]);
 	int count = atoi(argv[2]);
 

--- a/src/extract.c
+++ b/src/extract.c
@@ -46,6 +46,8 @@ int main_extract(int argc, char* argv[])
 	complex float* in_data = load_cfl(argv[argc - 2], DIMS, in_dims);
 	md_copy_dims(DIMS, out_dims, in_dims);
 
+	copy_if_equal_in_out(argv[argc - 1], argv[argc - 2], DIMS, in_dims, &in_data, "extract");
+
 	int count = argc - 3;
 	assert((count > 0) && (count % 3 == 0));
 

--- a/src/fftshift.c
+++ b/src/fftshift.c
@@ -19,6 +19,7 @@
 #include "misc/mmio.h"
 #include "misc/misc.h"
 
+
 #ifndef DIMS
 #define DIMS 16
 #endif
@@ -41,6 +42,9 @@ int main_fftshift(int argc, char* argv[])
 	long dims[N];
 
 	complex float* idata = load_cfl(argv[2], N, dims);
+
+	copy_if_equal_in_out(argv[3], argv[2], DIMS, dims, &idata, "fftshift");
+
 	complex float* odata = create_cfl(argv[3], N, dims);
 
 	(b ? ifftshift : fftshift)(N, dims, flags, odata, idata);

--- a/src/filter.c
+++ b/src/filter.c
@@ -54,6 +54,8 @@ int main_filter(int argc, char* argv[])
 	
 	complex float* in_data = load_cfl(argv[1], DIMS, in_dims);
 
+	copy_if_equal_in_out(argv[2], argv[1], DIMS, in_dims, &in_data, "filter");
+
 	assert(dim >= 0);
 	assert(dim < DIMS);
 	assert(len > 0);

--- a/src/flatten.c
+++ b/src/flatten.c
@@ -37,6 +37,8 @@ int main_flatten(int argc, char* argv[])
 
 	complex float* idata = load_cfl(argv[1], DIMS, idims);
 
+	copy_if_equal_in_out(argv[2], argv[1], DIMS, idims, &idata, "flatten");
+
 	long odims[DIMS] = MD_INIT_ARRAY(DIMS, 1);
 	odims[0] = md_calc_size(DIMS, idims);
 

--- a/src/flip.c
+++ b/src/flip.c
@@ -37,6 +37,10 @@ int main_flip(int argc, char* argv[])
 	int N = DIMS;
 	long dims[N];
 	complex float* idata = load_cfl(argv[2], N, dims);
+
+	copy_if_equal_in_out(argv[3], argv[2], DIMS, dims, &idata, "flip");
+
+
 	complex float* odata = create_cfl(argv[3], N, dims);
 
 	unsigned long flags = atoi(argv[1]);

--- a/src/lrmatrix.c
+++ b/src/lrmatrix.c
@@ -128,6 +128,8 @@ int main_lrmatrix(int argc, char* argv[])
 	// Load input
 	complex float* idata = load_cfl(argv[1], DIMS, idims);
 
+	copy_if_equal_in_out(argv[2], argv[1], DIMS, idims, &idata, "lrmatrix");
+
 	// Get levels and block dimensions
 	long blkdims[MAX_LEV][DIMS];
 	long levels;

--- a/src/misc/mmio.c
+++ b/src/misc/mmio.c
@@ -541,3 +541,21 @@ void unmap_cfl(unsigned int D, const long dims[D], const complex float* x)
 #endif
 }
 
+
+
+void copy_if_equal_in_out(const char* outf, const char* inf, unsigned int D, long dims[__VLA(D)], _Complex float** in, const char* toolname)
+{
+	if (0 == strcmp(inf, outf)) {
+
+		debug_printf(DP_WARN, "%s should not be called with identical input and output!\n", toolname);
+
+		complex float* tmp = *in;
+		*in = anon_cfl("", D, dims);
+
+		md_copy(D, dims, *in, tmp, sizeof(complex float));
+
+		unmap_cfl(D, dims, tmp);
+		io_unregister(inf);
+	}
+}
+

--- a/src/misc/mmio.h
+++ b/src/misc/mmio.h
@@ -25,6 +25,8 @@ extern _Complex float* load_zcoo(const char* name, unsigned int D, long dimensio
 extern _Complex float* create_zra(const char* name, unsigned int D, const long dims[__VLA(D)]);
 extern _Complex float* load_zra(const char* name, unsigned int D, long dims[__VLA(D)]);
 
+extern void copy_if_equal_in_out(const char* outf, const char* inf, unsigned int D, long dims[__VLA(D)], _Complex float** in, const char* toolname);
+
 #include "misc/cppwrap.h"
 
 

--- a/src/pattern.c
+++ b/src/pattern.c
@@ -47,6 +47,8 @@ int main_pattern(int argc, char* argv[])
 
 	complex float* kspace = load_cfl(argv[1], N, in_dims);
 
+	copy_if_equal_in_out(argv[2], argv[1], DIMS, in_dims, &kspace, "pattern");
+
 	md_select_dims(N, ~flags, out_dims, in_dims);
 	
 	complex float* pattern = create_cfl(argv[2], N, out_dims);

--- a/src/repmat.c
+++ b/src/repmat.c
@@ -35,7 +35,10 @@ int main_repmat(int argc, char* argv[])
 	long in_dims[DIMS];
 	long out_dims[DIMS];
 	
+
 	complex float* in_data = load_cfl(argv[3], DIMS, in_dims);
+
+	copy_if_equal_in_out(argv[4], argv[3], DIMS, in_dims, &in_data, "repmat");
 
 	int dim = atoi(argv[1]);
 	int rep = atoi(argv[2]);

--- a/src/reshape.c
+++ b/src/reshape.c
@@ -43,6 +43,8 @@ int main_reshape(int argc, char* argv[])
 
 	complex float* in_data = load_cfl(argv[n + 2], DIMS, in_dims);
 
+	copy_if_equal_in_out(argv[n + 3], argv[n + 2], DIMS, in_dims, &in_data, "reshape");
+
 	md_copy_dims(DIMS, out_dims, in_dims);
 	
 	unsigned int j = 0;

--- a/src/resize.c
+++ b/src/resize.c
@@ -57,6 +57,8 @@ int main_resize(int argc, char* argv[])
 
 	void* in_data = load_cfl(argv[argc - 2], N, in_dims);
 	md_copy_dims(N, out_dims, in_dims);
+
+	copy_if_equal_in_out(argv[argc - 1], argv[argc - 2], DIMS, in_dims, &in_data, "resize");
 	
 	for (int i = 0; i < count; i += 2) {
 

--- a/src/rss.c
+++ b/src/rss.c
@@ -39,6 +39,8 @@ int main_rss(int argc, char* argv[argc])
 	long dims[DIMS];
 	complex float* data = load_cfl(argv[2], DIMS, dims);
 
+	copy_if_equal_in_out(argv[3], argv[2], DIMS, dims, &data, "rss");
+
 	int flags = atoi(argv[1]);
 
 	assert(0 <= flags);

--- a/src/slice.c
+++ b/src/slice.c
@@ -51,6 +51,8 @@ int main_slice(int argc, char* argv[])
 	complex float* in_data = load_cfl(argv[argc - 2], DIMS, in_dims);
 	md_copy_dims(DIMS, out_dims, in_dims);
 
+	copy_if_equal_in_out(argv[argc - 1], argv[argc - 2], DIMS, in_dims, &in_data, "slice");
+
 	long pos2[DIMS] = { [0 ... DIMS - 1] = 0 };
 	unsigned long flags = 0L;
 

--- a/src/squeeze.c
+++ b/src/squeeze.c
@@ -37,7 +37,10 @@ int main_squeeze(int argc, char* argv[])
 	long odims[DIMS] = MD_INIT_ARRAY(DIMS, 1);
 
 	complex float* idata = load_cfl(argv[1], DIMS, idims);
-		
+
+	copy_if_equal_in_out(argv[2], argv[1], DIMS, idims, &idata, "squeeze");
+
+
 	unsigned int j = 0;
 
 	for (unsigned int i = 0; i < DIMS; i++)

--- a/src/std.c
+++ b/src/std.c
@@ -42,6 +42,8 @@ int main_std(int argc, char* argv[])
 
 	complex float* in = load_cfl(argv[2], DIMS, idims);
 
+	copy_if_equal_in_out(argv[3], argv[2], DIMS, idims, &in, "std");
+
 	md_select_dims(DIMS, ~flags, odims, idims);
 
 	complex float* out = create_cfl(argv[3], DIMS, odims);

--- a/src/transpose.c
+++ b/src/transpose.c
@@ -40,6 +40,8 @@ int main_transpose(int argc, char* argv[])
 
 	complex float* idata = load_cfl(argv[3], N, idims);
 
+	copy_if_equal_in_out(argv[4], argv[3], DIMS, idims, &idata, "transpose");
+
 	long odims[N];
 	md_transpose_dims(N, dim1, dim2, odims, idims);
 

--- a/src/var.c
+++ b/src/var.c
@@ -42,6 +42,8 @@ int main_var(int argc, char* argv[])
 
 	complex float* in = load_cfl(argv[2], DIMS, idims);
 
+	copy_if_equal_in_out(argv[3], argv[2], DIMS, idims, &in, "var");
+
 	md_select_dims(DIMS, ~flags, odims, idims);
 
 	complex float* out = create_cfl(argv[3], DIMS, odims);

--- a/src/whiten.c
+++ b/src/whiten.c
@@ -101,6 +101,9 @@ int main_whiten(int argc, char* argv[])
 	long mat_dims[DIMS];
 
 	complex float* idata = load_cfl(argv[1], DIMS, dims);
+
+	copy_if_equal_in_out(argv[3], argv[1], DIMS, dims, &idata, "whiten");
+
 	complex float* ndata = load_cfl(argv[2], DIMS, noise_dims);
 	complex float* odata = create_cfl(argv[3], DIMS, dims);
 


### PR DESCRIPTION
This is not for all commands, but I think for all commands where
it makes sense.

Closes #60 