### PR TITLE
Removed not necessary omp atomics

### DIFF
--- a/src/noncart/grid.c
+++ b/src/noncart/grid.c
@@ -334,10 +334,7 @@ void grid_pointH(unsigned int ch, int N, const long dims[VLA(N)], const float po
 	{
 		for (unsigned int c = 0; c < ch; c++) {
 
-			// we are allowed to update real and imaginary part independently which works atomically
-			#pragma omp atomic
 			__real(val[c]) += __real(src[ind + c * dims[0] * dims[1] * dims[2]]) * d;
-			#pragma omp atomic
 			__imag(val[c]) += __imag(src[ind + c * dims[0] * dims[1] * dims[2]]) * d;
 		}
 	};


### PR DESCRIPTION
Within ```grid_pointH()``` the omp atomics should not be necessary at this point because ```src``` is not modified and ```val``` ultimately is local to the thread per for loop iteration (see https://github.com/MartinK84/bart/blob/4f79ae12565e01e18d13d8356c60c8cadc53a5ac/src/noncart/grid.c#L117)