### PR TITLE
Fixed missing linop_free() for local intermediate variable

### DIFF
--- a/src/noncart/nufft.c
+++ b/src/noncart/nufft.c
@@ -746,6 +746,7 @@ struct linop_s* nufft_create2(unsigned int N,
 			auto nu2 = linop_loop(N, loop_dims, nu1);
 
 			linop_free(nu);
+			linop_free(nu1);
 
 			return nu2;
 		}


### PR DESCRIPTION
Just a small fix, but I think the variable nu1 is missing a linop_free()