### PR TITLE
Added parallelization to linear phase calculatulation in NUFFT prep

### DIFF
--- a/src/noncart/nufft.c
+++ b/src/noncart/nufft.c
@@ -95,6 +95,7 @@ static complex float* compute_linphases(int N, long lph_dims[N + 1], unsigned lo
 
 	complex float* linphase = md_alloc(ND, lph_dims, CFL_SIZE);
 
+	#pragma omp parallel for shared(linphase)
 	for(int i = 0; i < s; i++) {
 
 		float shifts2[ND];


### PR DESCRIPTION
Tested with 2D and 3D radial phantoms, speeds up the NUFFT preparation substantially, for larger 3D data by 30% or even more (depending on the computer used). Speed up also works for 2D data, although not that as substantial (but at least not slowing anything down)