### PR TITLE
Changed estimate_im_dims() to always round up

### DIFF
--- a/src/noncart/nufft.c
+++ b/src/noncart/nufft.c
@@ -1098,7 +1098,7 @@ void estimate_im_dims(int N, unsigned long flags, long dims[N], const long tdims
 
 		if (MD_IS_SET(flags, j)) {
 
-			dims[t] = (0. == max_dims[t]) ? 1 : (2 * (long)((2. * max_dims[t] + 1.5) / 2.));
+			dims[t] = (0. == max_dims[t]) ? 1 : (2 * ceilf(max_dims[t]));
 			t++;
 		}
 	}


### PR DESCRIPTION
I would like to propose the following change to the ```estimate_im_dims()``` functions, essentially making it always round the estimated image size up.

Given the following example (taken from the nlinv test)
```
bart traj -r -x256 -y21 traj.ra
bart scale 0.5 traj.ra traj2.ra
```
will create a trajectory (traj2) with a trajectory max size of 127.143486 in read and 127.5 in phase direction. The current estimate_im_dims() will consequently estimate the image size to [254  256]. However, this would mean that the trajectory point with coordinate 127.143486 will be outside of the grid in read direction. The proposed change would estimate the image size for the given example to [256  256], which I think would be more correct.

Both ```make test``` and ```make utest``` still work with the change.