### PR TITLE
Support identical input and output (v2)

### DIFF
--- a/src/join.c
+++ b/src/join.c
@@ -20,6 +20,7 @@
 #include "misc/debug.h"
 #include "misc/misc.h"
 #include "misc/opts.h"
+#include "misc/io.h"
 
 
 #ifndef DIMS
@@ -99,7 +100,6 @@ int main_join(int argc, char* argv[])
 		if (append && (i == 0)) {
 
 			name = argv[argc - 1];
-
 		} else {
 
 			name = argv[2 + l++];
@@ -114,6 +114,9 @@ int main_join(int argc, char* argv[])
 
 		for (int j = 0; j < N; j++)
 			assert((dim == j) || (in_dims[0][j] == in_dims[i][j]));
+
+		if (append && (i == 0))
+			unmap_cfl(N, in_dims[i], idata[i]);
 	}
 
 	long out_dims[N];
@@ -122,6 +125,13 @@ int main_join(int argc, char* argv[])
 		out_dims[i] = in_dims[0][i];
 
 	out_dims[dim] = sum;
+
+	if (append) {
+
+		// Here, we need to trick the IO subsystem into absolutely NOT
+		// unlinking our input, as the same file is also an output here.
+		io_unregister(argv[argc - 1]);
+	}
 
 	complex float* out_data = create_cfl(argv[argc - 1], N, out_dims);
 
@@ -141,10 +151,10 @@ int main_join(int argc, char* argv[])
 			md_calc_strides(N, istr, in_dims[i], CFL_SIZE);
 
 			md_copy_block(N, pos, out_dims, out_data, in_dims[i], idata[i], CFL_SIZE);
-		}
 
-		unmap_cfl(N, in_dims[i], idata[i]);
-		debug_printf(DP_DEBUG1, "done copying file %d\n", i);
+			unmap_cfl(N, in_dims[i], idata[i]);
+			debug_printf(DP_DEBUG1, "done copying file %d\n", i);
+		}
 	}
 
 	unmap_cfl(N, out_dims, out_data);

--- a/src/misc/io.c
+++ b/src/misc/io.c
@@ -125,7 +125,7 @@ void io_unregister(const char* name)
 			xfree(io->name);
 			xfree(io);
 
-			return;
+			continue;
 		}
 
 		iop = &io->prev;

--- a/src/misc/io.c
+++ b/src/misc/io.c
@@ -47,6 +47,28 @@ static void xdprintf(int fd, const char* fmt, ...)
 
 
 
+enum file_types_e file_type(const char* name)
+{
+	const char *p = strrchr(name, '.');
+
+	if ((NULL != p) && (p != name)) {
+
+		if (0 == strcmp(p, ".ra"))
+			return FILE_TYPE_RA;
+
+		if (0 == strcmp(p, ".coo"))
+			return FILE_TYPE_COO;
+
+#ifdef USE_MEM_CFL
+		if (0 == strcmp(p, ".mem"))
+			return MEM;
+#endif
+	}
+
+	return FILE_TYPE_CFL;
+}
+
+
 struct iofile_s {
 
 	const char* name;

--- a/src/misc/io.c
+++ b/src/misc/io.c
@@ -140,6 +140,53 @@ void io_memory_cleanup(void)
 }
 
 
+
+void io_unlink_if_opened(const char* name)
+{
+	const struct iofile_s* iop = iofiles;
+
+	while (NULL != iop) {
+
+		if (0 == strcmp(name, iop->name)) {
+
+			enum file_types_e type = file_type(name);
+
+			switch (type) {
+				case FILE_TYPE_RA:
+				case FILE_TYPE_COO:
+					if (0 != unlink(name))
+						error("Failed to unlink file %s\n", name);
+					break;
+
+				case FILE_TYPE_CFL:
+				{
+					char name_bdy[1024];
+					if (1024 <= snprintf(name_bdy, 1024, "%s.cfl", name))
+						error("Failed to unlink cfl file %s\n", name);
+
+					if (0 != unlink(name_bdy))
+						error("Failed to unlink file %s\n", name);
+
+					char name_hdr[1024];
+					if (1024 <= snprintf(name_hdr, 1024, "%s.hdr", name))
+						error("Failed to unlink cfl file %s\n", name);
+
+					if (0 != unlink(name_hdr))
+						error("Failed to unlink file %s\n", name);
+				}
+			}
+
+			io_unregister(name);
+
+			break;
+		}
+
+		iop = iop->prev;
+	}
+
+}
+
+
 int write_cfl_header(int fd, unsigned int n, const long dimensions[n])
 {
 	xdprintf(fd, "# Dimensions\n");

--- a/src/misc/io.h
+++ b/src/misc/io.h
@@ -1,6 +1,16 @@
 
 #include "misc/cppwrap.h"
 
+
+enum file_types_e {
+	FILE_TYPE_CFL, FILE_TYPE_RA, FILE_TYPE_COO,
+#ifdef USE_MEM_CFL
+	FILE_TYPE_MEM,
+#endif
+};
+
+extern enum file_types_e file_type(const char* name);
+
 extern int write_ra(int fd, unsigned int n, const long dimensions[__VLA(n)]);
 extern int read_ra(int fd, unsigned int n, long dimensions[__VLA(n)]);
 

--- a/src/misc/io.h
+++ b/src/misc/io.h
@@ -24,6 +24,8 @@ extern void io_register_input(const char* name);
 extern void io_register_output(const char* name);
 extern void io_unregister(const char* name);
 
+extern void io_unlink_if_opened(const char* name);
+
 extern void io_memory_cleanup(void);
 
 #include "misc/cppwrap.h"

--- a/src/misc/mmio.c
+++ b/src/misc/mmio.c
@@ -300,7 +300,7 @@ float* load_coo(const char* name, unsigned int D, long dims[D])
 
 	void* addr;
 	struct stat st;
-        
+
 	if (-1 == fstat(fd, &st))
 		io_error("Loading coo file %s\n", name);
 

--- a/src/misc/mmio.c
+++ b/src/misc/mmio.c
@@ -239,6 +239,7 @@ complex float* create_zcoo(const char* name, unsigned int D, const long dimensio
 
 complex float* create_cfl(const char* name, unsigned int D, const long dimensions[D])
 {
+	io_unlink_if_opened(name);
 	io_register_output(name);
 
 #ifdef MEMONLY_CFL

--- a/src/misc/mmio.c
+++ b/src/misc/mmio.c
@@ -114,37 +114,37 @@ complex float* load_zra(const char* name, unsigned int D, long dims[D])
 {
 	int fd;
 	if (-1 == (fd = open(name, O_RDONLY)))
-		io_error("Loading ra file %s", name);
+		io_error("Loading ra file %s\n", name);
 
 	if (-1 == read_ra(fd, D, dims))
-		error("Loading ra file %s", name);
+		error("Loading ra file %s\n", name);
 
 	long T;
 	if (-1 == (T = io_calc_size(D, dims, sizeof(complex float))))
-		error("Loading ra file %s", name);
+		error("Loading ra file %s\n", name);
 
 	void* addr;
 	struct stat st;
 
 	if (-1 == fstat(fd, &st))
-		io_error("Loading ra file %s", name);
+		io_error("Loading ra file %s\n", name);
 
 	off_t header_size;
 
 	if (-1 == (header_size = lseek(fd, 0, SEEK_CUR)))
-		io_error("Loading ra file %s", name);
+		io_error("Loading ra file %s\n", name);
 
 	// ra allows random stuff at the end
 	if (T + header_size > st.st_size)
-		error("Loading ra file %s", name);
+		error("Loading ra file %s\n", name);
 
 	assert(header_size < 4096);
 
 	if (MAP_FAILED == (addr = mmap(NULL, st.st_size, PROT_READ|PROT_WRITE, MAP_PRIVATE, fd, 0)))
-		io_error("Loading ra file %s", name);
+		io_error("Loading ra file %s\n", name);
 
 	if (-1 == close(fd))
-		io_error("Loading ra file %s", name);
+		io_error("Loading ra file %s\n", name);
 
 	return (complex float*)(addr + header_size);;
 }
@@ -169,27 +169,27 @@ complex float* create_zra(const char* name, unsigned int D, const long dims[D])
 {
 	int ofd;
 	if (-1 == (ofd = open(name, O_RDWR|O_CREAT, S_IRUSR|S_IWUSR)))
-		io_error("Creating ra file %s", name);
+		io_error("Creating ra file %s\n", name);
 
 	if (-1 == write_ra(ofd, D, dims))
-		error("Creating ra file %s", name);
+		error("Creating ra file %s\n", name);
 
 	long T;
 	if (-1 == (T = io_calc_size(D, dims, sizeof(complex float))))
-		error("Creating ra file %s", name);
+		error("Creating ra file %s\n", name);
 
 	off_t header_size;
 
 	if (-1 == (header_size = lseek(ofd, 0, SEEK_CUR)))
-		io_error("Creating ra file %s", name);
+		io_error("Creating ra file %s\n", name);
 
 	void* data;
 
 	if (NULL == (data = create_data(ofd, header_size, T)))
-		error("Creating ra file %s", name);
+		error("Creating ra file %s\n", name);
 
 	if (-1 == close(ofd))
-		io_error("Creating ra file %s", name);
+		io_error("Creating ra file %s\n", name);
 
 	return (complex float*)data;
 }
@@ -201,23 +201,23 @@ float* create_coo(const char* name, unsigned int D, const long dims[D])
 	int ofd;
 
 	if (-1 == (ofd = open(name, O_RDWR|O_CREAT, S_IRUSR|S_IWUSR)))
-		io_error("Creating coo file %s", name);
+		io_error("Creating coo file %s\n", name);
 
 	if (-1 == write_coo(ofd, D, dims))
-		error("Creating coo file %s", name);
+		error("Creating coo file %s\n", name);
 
 	long T;
 
 	if (-1 == (T = io_calc_size(D, dims, sizeof(float))))
-		error("Creating coo file %s", name);
+		error("Creating coo file %s\n", name);
 
 	void* addr;
 
 	if (NULL == (addr = create_data(ofd, 4096, T)))
-		error("Creating coo file %s", name);
+		error("Creating coo file %s\n", name);
 
 	if (-1 == close(ofd))
-		io_error("Creating coo file %s", name);
+		io_error("Creating coo file %s\n", name);
 
 	return (float*)addr;
 }
@@ -260,21 +260,21 @@ complex float* create_cfl(const char* name, unsigned int D, const long dimension
  
 	char name_bdy[1024];
 	if (1024 <= snprintf(name_bdy, 1024, "%s.cfl", name))
-		error("Creating cfl file %s", name);
+		error("Creating cfl file %s\n", name);
 
 	char name_hdr[1024];
 	if (1024 <= snprintf(name_hdr, 1024, "%s.hdr", name))
-		error("Creating cfl file %s", name);
+		error("Creating cfl file %s\n", name);
 
 	int ofd;
 	if (-1 == (ofd = open(name_hdr, O_RDWR|O_CREAT|O_TRUNC, S_IRUSR|S_IWUSR)))
-		io_error("Creating cfl file %s", name);
+		io_error("Creating cfl file %s\n", name);
 
 	if (-1 == write_cfl_header(ofd, D, dimensions))
-		error("Creating cfl file %s", name);
+		error("Creating cfl file %s\n", name);
 
 	if (-1 == close(ofd))
-		io_error("Creating cfl file %s", name);
+		io_error("Creating cfl file %s\n", name);
 
 	return shared_cfl(D, dimensions, name_bdy);
 #endif /* MEMONLY_CFL */
@@ -288,30 +288,30 @@ float* load_coo(const char* name, unsigned int D, long dims[D])
 	int fd;
 
 	if (-1 == (fd = open(name, O_RDONLY)))
-		io_error("Loading coo file %s", name);
+		io_error("Loading coo file %s\n", name);
 
 	if (-1 == read_coo(fd, D, dims))
-		error("Loading coo file %s", name);
+		error("Loading coo file %s\n", name);
 
 	long T;
 
 	if (-1 == (T = io_calc_size(D, dims, sizeof(float))))
-		error("Loading coo file %s", name);
+		error("Loading coo file %s\n", name);
 
 	void* addr;
 	struct stat st;
         
 	if (-1 == fstat(fd, &st))
-		io_error("Loading coo file %s", name);
+		io_error("Loading coo file %s\n", name);
 
 	if (T + 4096 != st.st_size)
-		error("Loading coo file %s", name);
+		error("Loading coo file %s\n", name);
 
 	if (MAP_FAILED == (addr = mmap(NULL, T, PROT_READ|PROT_WRITE, MAP_PRIVATE, fd, 4096)))
-		io_error("Loading coo file %s", name);
+		io_error("Loading coo file %s\n", name);
 
 	if (-1 == close(fd))
-		io_error("Loading coo file %s", name);
+		io_error("Loading coo file %s\n", name);
 
 	return (float*)addr;
 }
@@ -323,7 +323,7 @@ complex float* load_zcoo(const char* name, unsigned int D, long dimensions[D])
 	float* data = load_coo(name, D + 1, dims);
 
 	if (2 != dims[0])
-		error("Loading coo file %s", name);
+		error("Loading coo file %s\n", name);
 
 	memcpy(dimensions, dims + 1, D * sizeof(long));
 
@@ -341,7 +341,7 @@ static complex float* load_cfl_internal(const char* name, unsigned int D, long d
 	complex float* ptr = load_mem_cfl(name, D, dimensions);
 
 	if (NULL == ptr)
-		io_error("Loading in-memory cfl file %s", name);
+		io_error("Loading in-memory cfl file %s\n", name);
 
 	return ptr;
 #else
@@ -369,21 +369,21 @@ static complex float* load_cfl_internal(const char* name, unsigned int D, long d
 
 	char name_bdy[1024];
 	if (1024 <= snprintf(name_bdy, 1024, "%s.cfl", name))
-		error("Loading cfl file %s", name);
+		error("Loading cfl file %s\n", name);
 
 	char name_hdr[1024];
 	if (1024 <= snprintf(name_hdr, 1024, "%s.hdr", name))
-		error("Loading cfl file %s", name);
+		error("Loading cfl file %s\n", name);
 
 	int ofd;
 	if (-1 == (ofd = open(name_hdr, O_RDONLY)))
-		io_error("Loading cfl file %s", name);
+		io_error("Loading cfl file %s\n", name);
 
 	if (-1 == read_cfl_header(ofd, D, dimensions))
-		error("Loading cfl file %s", name);
+		error("Loading cfl file %s\n", name);
 
 	if (-1 == close(ofd))
-		io_error("Loading cfl file %s", name);
+		io_error("Loading cfl file %s\n", name);
 
 	return (priv ? private_cfl : shared_cfl)(D, dimensions, name_bdy);
 #endif /* MEMONLY_CFL */
@@ -411,12 +411,12 @@ complex float* shared_cfl(unsigned int D, const long dims[D], const char* name)
 	long T;
 
 	if (-1 == (T = io_calc_size(D, dims, sizeof(complex float))))
-		error("shared cfl %s", name);
+		error("shared cfl %s\n", name);
 
 	err_assert(T > 0);
 
         if (-1 == (fd = open(name, O_RDWR|O_CREAT, S_IRUSR|S_IWUSR)))
-		io_error("shared cfl %s", name);
+		io_error("shared cfl %s\n", name);
 
 //	if (-1 == (fstat(fd, &st)))
 //		error("abort");
@@ -425,10 +425,10 @@ complex float* shared_cfl(unsigned int D, const long dims[D], const char* name)
 //		error("abort");
 
 	if (NULL == (addr = create_data(fd, 0, T)))
-		error("shared cfl %s", name);
+		error("shared cfl %s\n", name);
 
 	if (-1 == close(fd))
-		io_error("shared cfl %s", name);
+		io_error("shared cfl %s\n", name);
 
 	return (complex float*)addr;
 }
@@ -444,10 +444,10 @@ complex float* anon_cfl(const char* name, unsigned int D, const long dims[D])
 	long T;
 
 	if (-1 == (T = io_calc_size(D, dims, sizeof(complex float))))
-		error("anon cfl");
+		error("anon cfl\n");
 
 	if (MAP_FAILED == (addr = mmap(NULL, T, PROT_READ|PROT_WRITE, MAP_ANONYMOUS|MAP_PRIVATE, -1, 0)))
-		io_error("anon cfl");
+		io_error("anon cfl\n");
 
 	return (complex float*)addr;
 #else
@@ -489,26 +489,26 @@ complex float* private_cfl(unsigned int D, const long dims[D], const char* name)
 	long T;
 
 	if (-1 == (T = io_calc_size(D, dims, sizeof(complex float))))
-		error("private cfl %s", name);
+		error("private cfl %s\n", name);
 
 	int fd;
 	void* addr;
 	struct stat st;
 
 	if (-1 == (fd = open(name, O_RDONLY)))
-		io_error("private cfl %s", name);
+		io_error("private cfl %s\n", name);
 
 	if (-1 == (fstat(fd, &st)))
-		io_error("private cfl %s", name);
+		io_error("private cfl %s\n", name);
 
 	if (T != st.st_size)
-		error("private cfl %s", name);
+		error("private cfl %s\n", name);
 
 	if (MAP_FAILED == (addr = mmap(NULL, T, PROT_READ|PROT_WRITE, MAP_PRIVATE, fd, 0)))
-		io_error("private cfl %s", name);
+		io_error("private cfl %s\n", name);
 
 	if (-1 == close(fd))
-		io_error("private cfl %s", name);
+		io_error("private cfl %s\n", name);
 
 	return (complex float*)addr;
 }
@@ -534,10 +534,10 @@ void unmap_cfl(unsigned int D, const long dims[D], const complex float* x)
 	long T;
 
 	if (-1 == (T = io_calc_size(D, dims, sizeof(complex float))))
-		error("unmap cfl");
+		error("unmap cfl\n");
 
 	if (-1 == munmap((void*)((uintptr_t)x & ~4095UL), T))
-		io_error("unmap cfl");
+		io_error("unmap cfl\n");
 #endif
 }
 

--- a/tests/io.mk
+++ b/tests/io.mk
@@ -1,0 +1,24 @@
+
+# This tests if identical input and output is supported
+# The hope is that, if it works in these tools, it will also work in all others
+tests/test-io: ones slice nrmse
+	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)						;\
+	$(TOOLDIR)/ones 2 50 50 a.ra								;\
+	$(TOOLDIR)/slice 0 12 a.ra b.ra								;\
+	$(TOOLDIR)/slice 0 12 a.ra a.ra								;\
+	$(TOOLDIR)/nrmse -t 0. a.ra b.ra							;\
+	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
+	touch $@
+
+tests/test-io2: ones std noise nrmse
+	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)						;\
+	$(TOOLDIR)/ones 2 50 50 a.ra								;\
+	$(TOOLDIR)/noise a.ra b.ra								;\
+	$(TOOLDIR)/std 3 b.ra c.ra								;\
+	$(TOOLDIR)/std 3 b.ra b.ra								;\
+	$(TOOLDIR)/nrmse -t 0. b.ra c.ra							;\
+	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
+	touch $@
+
+TESTS += tests/test-io tests/test-io2
+


### PR DESCRIPTION
In this version, whenever we create an output that has already been specified as an input, we unlink the file before recreating it.

As we already have a memory map to the input, deleting it from the filesystem does not change that map. And after creating the output (especially if it has a different size from the input), the original input file is unusable anyway.

There is only one difficulty: the join command. Here, we specifically want to extend an input, and therefore we cannot remove it. The solution is to pretend that it isn't an input (by calling `io_unregsiter`) and then opening it with `create_cfl`.

Related changes are a new file_type function which returns an enum to get the file_type from its name. Additionally, `io_unregister` now removes all IOs of that name from the list.

Closes #60 .