### PR TITLE
Added support for non squared image sizes to nlinv

### DIFF
--- a/src/nlinv.c
+++ b/src/nlinv.c
@@ -130,9 +130,6 @@ int main_nlinv(int argc, char* argv[])
 	md_calc_strides(DIMS, ksp_strs, ksp_dims, CFL_SIZE);
 
 	long dims[DIMS];
-	md_copy_dims(DIMS, dims, ksp_dims);
-	dims[MAPS_DIM] = nmaps;
-
 
 	complex float* traj = NULL;
 	long trj_dims[DIMS];
@@ -145,9 +142,13 @@ int main_nlinv(int argc, char* argv[])
 
 		md_zsmul(DIMS, trj_dims, traj, traj, 2.);
 
-		//if (0 == md_calc_size(3, sens_dims))
-			estimate_fast_sq_im_dims(3, dims, trj_dims, traj);
+		estimate_im_dims(DIMS, FFT_FLAGS, dims, trj_dims, traj);
+		debug_printf(DP_INFO, "Est. image size: %ld %ld %ld\n", dims[0], dims[1], dims[2]);
+		md_copy_dims(DIMS - 3, dims + 3, ksp_dims + 3);
+	} else {
+		md_copy_dims(DIMS, dims, ksp_dims);
 	}
+	dims[MAPS_DIM] = nmaps;
 
 	long strs[DIMS];
 	md_calc_strides(DIMS, strs, dims, CFL_SIZE);

--- a/src/nlinv.c
+++ b/src/nlinv.c
@@ -130,6 +130,8 @@ int main_nlinv(int argc, char* argv[])
 	md_calc_strides(DIMS, ksp_strs, ksp_dims, CFL_SIZE);
 
 	long dims[DIMS];
+	md_copy_dims(DIMS, dims, ksp_dims);
+	dims[MAPS_DIM] = nmaps;
 
 	complex float* traj = NULL;
 	long trj_dims[DIMS];
@@ -145,10 +147,7 @@ int main_nlinv(int argc, char* argv[])
 		estimate_im_dims(DIMS, FFT_FLAGS, dims, trj_dims, traj);
 		debug_printf(DP_INFO, "Est. image size: %ld %ld %ld\n", dims[0], dims[1], dims[2]);
 		md_copy_dims(DIMS - 3, dims + 3, ksp_dims + 3);
-	} else {
-		md_copy_dims(DIMS, dims, ksp_dims);
-	}
-	dims[MAPS_DIM] = nmaps;
+	}	
 
 	long strs[DIMS];
 	md_calc_strides(DIMS, strs, dims, CFL_SIZE);


### PR DESCRIPTION
The proposed changes add support for non squared image sizes to the nlinv algorithm. ```make test``` and ```make utest``` still work and I have tested this on 3D radial data acquired with various combinations of reduced field of views and anisotropic resolution. 

Regarding reconstructed images size and FoV the nlinv images are now identical compared to what comes out when just using the BART NUFFT on the same data. The only difference is that nlinv appears to be working with twice the grid/img size internally (I guess to use and reconstruct the oversampled grid and shift border FoV artifacts outwards) which can, depending on the trajectory, lead to a +/-1 difference in output img size due to rounding difference in estimate_im_dims() between traj and 2 * traj.  But the latter should be fine and can't be avoided in my opinion.