### PR TITLE
Version fix

### DIFF
--- a/git-version.sh
+++ b/git-version.sh
@@ -2,9 +2,9 @@
 
 if test -d ${GIT_DIR:-.git} -o -f .git
 then
-    git describe --match "v*" --dirty
+    git describe --abbrev=7 --match "v*" --dirty
     if [[ $? -eq 0 ]]; then
-	git describe --match "v*" | cut -f1 -d'-' > version.txt
+	git describe --abbrev=7 --match "v*" | cut -f1 -d'-' > version.txt
     else
 	var=`cat version.txt`
 	echo ${var}-dirty

--- a/src/version.c
+++ b/src/version.c
@@ -38,7 +38,7 @@ static bool parse_version(const char* version, unsigned int v[5])
 
 	v[3] = 0;	// patch level
 
-	int ret = sscanf(version, "v%u.%u.%u%n-%u-g%*7[0-9a-f]%n-dirty%n", &v[0], &v[1], &v[2], &q, &v[3], &r, &s);
+	int ret = sscanf(version, "v%u.%u.%u%n-%u-g%*40[0-9a-f]%n-dirty%n", &v[0], &v[1], &v[2], &q, &v[3], &r, &s);
 
 	if (!(   ((3 == ret) && (len == q))
 	      || ((4 == ret) && (len == r))

--- a/tests/version.mk
+++ b/tests/version.mk
@@ -1,0 +1,8 @@
+
+
+# check if bart can parse its own version
+tests/test-version: version
+	$(TOOLDIR)/version -t `cat $(TOOLDIR)/version.txt`
+	touch $@
+
+TESTS += tests/test-version


### PR DESCRIPTION
Since git version v2.11, git describe does not always use 7 characters
for its commit hash. This broke bart version parsing, which always
expected 7 characters.

So now git-version.sh forces 7 characters, and additionally the parsing
now accepts up to 40 characters in the commit hash.