### PR TITLE
Fix: add target for libismrm.a if ISMRMRD enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,6 +479,9 @@ lib/lib$(1).a: lib$(1).a($$($(1)objs))
 endef
 
 ALIBS = misc num grecon sense noir iter linops wavelet lowrank noncart calib simu sake dfwavelet nlops moba lapacke box geom
+ifeq ($(ISMRMRD),1)
+ALIBS += ismrm
+endif
 $(eval $(foreach t,$(ALIBS),$(eval $(call alib,$(t)))))
 
 


### PR DESCRIPTION
Hi,

I was trying to compile bart with support for ISMRMRD and had to create an additional target for `libismrm.a` for it to work.
Please excuse me if this patch is not needed.

Also, I did not include it in this patch, but it may be better to change the default MKL_BASE from `/opt/intel/mkl/lib/intel64/` to `/opt/intel/mkl/`, since the lib suffix is already hard-coded later (line [367](https://github.com/mrirecon/bart/blob/336a48bfb37f59a2907a606fcf1536f3d635f4b7/Makefile#L367)).

Many thanks for your hard work,

Yael