### PR TITLE
Bart for Centos 7 + adhere to fedora packaging guidelines

### DIFF
--- a/bart.spec
+++ b/bart.spec
@@ -1,13 +1,13 @@
 Name:           bart
-Version:        {{{ bart_git_version_dots }}} 
-%define build_timestamp %{lua: print(os.date("%Y%m%d"))}
-Release:        %{build_timestamp}%{?dist}
+Version:        {{{ bart_version }}} 
+Release:        {{{ bart_release }}}%{?dist}
+Epoch:          1
 Summary:        tools for computational magnetic resonance imaging 
 
 License:        BSD
 URL:            https://mrirecon.github.io/bart
 VCS:            {{{ git_dir_vcs }}}
-Source0:        {{{ git_dir_pack source_name=bart dir_name=bart}}} 
+Source0:        {{{ git_dir_pack source_name=bart dir_name=bart }}}
 
 BuildRequires:  gcc, make, fftw-devel, lapack-devel, openblas-devel, atlas-devel, libpng-devel
 Requires:       fftw, lapack, openblas, atlas, libpng

--- a/bart.spec
+++ b/bart.spec
@@ -9,7 +9,12 @@ URL:            https://mrirecon.github.io/bart
 VCS:            {{{ git_dir_vcs }}}
 Source0:        {{{ git_dir_pack source_name=bart dir_name=bart }}}
 
+%if 0%{?rhel} == 07
+BuildRequires:  fftw-devel, lapack-devel, openblas-devel, atlas-devel, libpng-devel, devtoolset-7-toolchain, devtoolset-7-libatomic-devel
+%else
 BuildRequires:  gcc, make, fftw-devel, lapack-devel, openblas-devel, atlas-devel, libpng-devel
+%endif
+
 Requires:       fftw, lapack, openblas, atlas, libpng
 
 %description
@@ -25,6 +30,12 @@ The Berkeley Advanced Reconstruction Toolbox (BART) is a free and open-source im
 echo {{{ bart_git_version }}} > version.txt
 
 %build
+%if 0%{?rhel} == 07
+
+. /opt/rh/devtoolset-7/enable
+
+%endif
+
 make PARALLEL=1
 
 %install

--- a/libbart-devel.spec
+++ b/libbart-devel.spec
@@ -1,13 +1,13 @@
 Name:           libbart-devel
-Version:        {{{ bart_git_version_dots }}} 
-%define build_timestamp %{lua: print(os.date("%Y%m%d"))}
-Release:        %{build_timestamp}%{?dist}
+Version:        {{{ bart_version }}}
+Release:        {{{ bart_release }}}%{?dist}
+Epoch:          1
 Summary:        Development files for BART 
 
 License:        BSD
 URL:            https://mrirecon.github.io/bart
 VCS:            {{{ git_dir_vcs }}}
-Source0:        {{{ git_dir_pack source_name=libbart-devel dir_name=libbart-devel }}} 
+Source0:        {{{ git_dir_pack source_name=libbart-devel dir_name=libbart-devel }}}
 
 BuildRequires:  gcc, make, fftw-devel, lapack-devel, openblas-devel, atlas-devel, libpng-devel
 

--- a/octave-bart.spec
+++ b/octave-bart.spec
@@ -1,14 +1,14 @@
 %global octpkg bart
 Name:           octave-%{octpkg}
-Version:        {{{ bart_git_version_dots }}} 
-%define build_timestamp %{lua: print(os.date("%Y%m%d"))}
-Release:        %{build_timestamp}%{?dist}
+Version:        {{{ bart_version }}}
+Release:        {{{ bart_release }}}%{?dist}
+Epoch:          1
 Summary:        Octave bindings for BART
 
 License:        BSD
 URL:            https://mrirecon.github.io/bart
 VCS:            {{{ git_dir_vcs }}}
-Source0:        {{{ git_dir_pack source_name=octave-bart dir_name=octave-bart }}} 
+Source0:        {{{ git_dir_pack source_name=octave-bart dir_name=octave-bart }}}
 BuildArch:      noarch
 
 BuildRequires:  octave-devel

--- a/rpkg.macros
+++ b/rpkg.macros
@@ -1,6 +1,20 @@
-function bart_git_version_dots() {
-    ./git-version.sh | tr - . | tr -d '\n'
+function bart_version() {
+    ./git-version.sh | cut -d'-' -f1 | tr -d 'v\n'
 }
+
+function bart_release() {
+    git describe --match "v*" --exact > /dev/null 2>&1
+    if [[ $? -ne 0 ]]; then
+        release=$(($(./git-version.sh | cut -d'-' -f2) + 1))
+        date=$(date '+%Y%m%d')
+        commit=$(git rev-parse --short=7 HEAD)
+        release=$release"."$date"git"$commit
+    else
+        release=1
+    fi
+    echo -n $release
+}
+
 function bart_git_version() {
     ./git-version.sh | tr -d '\n'
 }


### PR DESCRIPTION
Hi!
This pull request contains changes to build RPMs for Centos 7:
I use the devtoolset-7 package for recent compilers.

The other commit is a new versioning scheme for the RPM packages:
So far it was the output of git-version.sh, but that leads to problems after major releases:
`bart-v0.7.00.1.gasdfasd-20210311.fc33.x86_64`
would look 'older' to the package manager then
`bart-v0.7.00.fc33.x86_64` -> no updates.

The new style would be
`bart-0.7.00-1.fc33.x86_64` (a tagged version)
`bart-0.7.00-2.20210311gitasdfasd.fc33.x86_64` (untagged version 1 commit after the last tag, built on that date)
which can be sorted correctly and should also match the guidelines at https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/.