### PR TITLE
cfl.py: faster write_cfl

### DIFF
--- a/python/cfl.py
+++ b/python/cfl.py
@@ -72,7 +72,9 @@ def writecfl(name, array):
     with open(name + ".cfl", "a+b") as d:
         os.ftruncate(d.fileno(), size)
         mm = mmap.mmap(d.fileno(), size, flags=mmap.MAP_SHARED, prot=mmap.PROT_WRITE)
-        mm.write(array.astype(np.complex64).tobytes(order='F'))
+        if array.dtype != np.complex64:
+            array = array.astype(np.complex64)
+        mm.write(np.ascontiguousarray(array.T))
         mm.close()
         #with mmap.mmap(d.fileno(), size, flags=mmap.MAP_SHARED, prot=mmap.PROT_WRITE) as mm:
         #    mm.write(array.astype(np.complex64).tobytes(order='F'))
@@ -106,5 +108,7 @@ def writemulticfl(name, arrays):
         os.ftruncate(d.fileno(), size)
         mm = mmap.mmap(d.fileno(), size, flags=mmap.MAP_SHARED, prot=mmap.PROT_WRITE)
         for array in arrays:
-            mm.write(array.astype(np.complex64).tobytes(order='F'))
+            if array.dtype != np.complex64:
+                array = array.astype(np.complex64)
+            mm.write(np.ascontiguousarray(array.T))
         mm.close()


### PR DESCRIPTION
Working on a python-based reconstruction that uses bart via the bart.py interface, I noticed that in my specific case write_cfl required a similar amount of time as the bart ecalib & pics operations.

Since my data is already in complex64 format, I added a dtype check before calling astype() which saved roughly 5% of computation time. More importantly, using ascontiguousarray() instead of tobytes() reduced the computation time by approximately 50% (10s vs 20s for a 256x256x256x32 test dataset with tempfile.tempdir = "/dev/shm").