### PR TITLE
hands_on_materials

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -1,0 +1,141 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="de">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+    <title>BART Toolbox</title>
+    <style type="text/css">
+
+        BODY {
+		background: #292638;
+        }
+
+	h1, h2 {
+		font-family: 'PT Serif', serif;
+		border-bottom: 1px solid grey;
+		padding-bottom: 5px;
+	}
+
+	h1 {
+		border-top: 1px solid grey;
+		padding-top: 5px;
+		font-size: 30px;
+	}
+
+	h2 {
+		font-size: 24px;
+	}
+
+        div#index {
+                position: fixed;
+	        padding: 10px 15px 10px;
+		background: #FFFFFF;
+                width: 10%;
+        }
+
+        div#body {
+	        width: 60%;
+	        padding: 10px 15px 10px;
+		background: #FFFFFF;
+        }
+
+	.github {
+		padding: 3px;
+		color: white;
+		border-radius: 5px;
+		background: url(./imgs/GitHub-Mark-Light-64px.png) no-repeat 2% 50% #33f;
+		background-size: 12%;
+		padding-left: 25px;
+	}
+
+        div A {
+        }
+
+        div A:visited {
+        }
+
+        div A:hover {
+        }
+
+	.code {
+		border: 1px solid black;
+		background: #DDDDDD;
+	}
+
+	.alert {
+		border: 5px solid red;
+		padding-top: 5px;
+		font-size: 24px;
+	}
+
+	code {
+	}
+
+	img, object {
+        	max-width: 100%;
+	}
+
+    </style>
+  </head>
+  <body>
+    <center>
+	    <div id="body" align="left">
+	<img src="./imgs/banner.png" width="100%"><p>
+<h1>BART News Archive </h1>
+<p>This webpage includes information about previous BART tutorials, workshops & webinars.
+</p>
+
+<h2>BART Events 2021 </h2>
+
+We are excited to announce a new series of virtual events!
+<p>
+<strong>1. BART user-support meeting</strong>
+<br>
+This meeting is open to all (no registration required)
+<br>
+Time: May 12, 2021, at 8am-9am US-PDT.
+<br>
+In this online meeting our team will be available to assist users with installing BART and answering any questions related to BART usage.
+<br>
+
+The zoom link will be sent to our users list
+<a href="https://lists.eecs.berkeley.edu/sympa/info/mrirecon">mrirecon</a>
+one day before the meeting. Sign up to receive updates!
+<br>
+Check your local time
+<a href="https://www.timeanddate.com/worldclock/fixedtime.html?msg=BART+users+support+meeting&iso=20210512T08&p1=791&ah=1">here</a>.
+</p>
+
+<p>
+<strong>  2. ISMRM software demo: Non-linear models and deep learning </strong>
+<br>
+Time: May 16, 2021, at 12pm PST
+<br>
+As part of the ISMRM 2021 meeting, we will be giving a demo of the new features of BART related to non-linear model-based reconstruction and deep learning integration.
+<br>
+Please note that you must be registered for the ISMRM 2021 meeting in order to attend.
+<br>
+For more information, see <a href="./ismrm21.html">here</a>.
+<br>
+
+Check your local time
+<a href="https://www.timeanddate.com/worldclock/fixedtime.html?msg=BART+Software+Demo+in+ISMRM+2021&iso=20210516T19&ah=1">here</a>.
+</p>
+
+<p>
+<strong>
+3. BART Webinar -  Parallel-Imaging Compressed Sensing Recon </strong>
+<br>
+Time: July 14, 2021, at 8am PST.
+<br>
+More details soon.
+</p>
+
+
+<h2 id="acknowledgements">Acknowledgements</h2>
+<p>This work is supported by NIH Grant U24EB029240-01.</p>
+<hr />
+</p>
+	</div>
+    </center>
+  </body>
+</html>

--- a/features.html
+++ b/features.html
@@ -78,26 +78,20 @@
   </head>
   <body>
     <center>
-    <p>
-    <div id="body" align="left">
+	    <div id="body" align="left">
 	<img src="./imgs/banner.png" width="100%"><p>
-      <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
-	<p>
-    <div>Quick Links:  <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
+<h1>BART Hands-on Material: Tutorials, Workshops & Webinars</h1>
+
+<div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
 
 <hr>
 
 
-	<p>
-	<div id="fig">
-	<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
-	<strong>Figure:</strong> Simulated MRI images.
-
-	<p>
-	</div>
-
-
-
+<p>
+<div id="fig">
+<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
+<strong>Figure:</strong> Simulated MRI images.
+</div>
 	<h2>List of Features</h2>
 	<p>
 	<ul>

--- a/features.html
+++ b/features.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick Links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+    <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
 <hr>
 

--- a/features.html
+++ b/features.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+    <div>Quick Links:  <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
 <hr>
 
@@ -98,7 +98,7 @@
 	<h2>List of Features</h2>
 	<p>
 	<ul>
-	<li>basic features:
+	<li>Basic features:
 		<ul>
 		<li>runs on Linux and Mac OS X</li>
 		<li>multi-dimensional operations on arrays</li>
@@ -107,7 +107,7 @@
 		<li>parallel computation on multiple cores and with <strong>Graphical Processing Units (GPU)</strong></li>
 		</ul>
 	</li>
-	<li>iterative methods:
+	<li>Iterative methods:
 		<ul>
 		<li>Conjugate Gradients (CG)</li>
 		<li>(Fast) Iterative Soft-Thresholding Algorithm (ISTA and FISTA)</li>
@@ -117,7 +117,7 @@
 		<li>Chambolle-Pock primal-dual algorithm</li>
 		</ul>
 	</li>
-	<li>calibration methods:
+	<li>Calibration methods:
 		<ul>
 		<li>direct calibration of coil sensitivities from k-space center</li>
 		<li>Walsh's method for calibration of coil sensitivities</li>
@@ -136,7 +136,7 @@
 		<li>methods based on <strong>deep learning</strong>: variational networks and MoDL</li>
 		</ul>
 	</li>
-	<li>regularization (in arbitrary dimensions):
+	<li>Regularization (in arbitrary dimensions):
 		<ul>
 		<li>Tikhonov</li>
 		<li>total variation</li>

--- a/features.html
+++ b/features.html
@@ -85,8 +85,6 @@
 	<p>
     <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
-
-
 <hr>
 
 	<small>

--- a/features.html
+++ b/features.html
@@ -92,7 +92,10 @@
 	<div id="fig">
 	<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
 	<strong>Figure:</strong> Simulated MRI images.
+</small>
+	<p>
 	</div>
+
 
 
 	<h2>List of Features</h2>

--- a/features.html
+++ b/features.html
@@ -83,16 +83,16 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick Links:  <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+    <div>Quick Links:  <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
 
 <hr>
 
-	<small>
+
 	<p>
 	<div id="fig">
 	<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
 	<strong>Figure:</strong> Simulated MRI images.
-</small>
+
 	<p>
 	</div>
 

--- a/features.html
+++ b/features.html
@@ -1,0 +1,153 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="de">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+    <title>BART Toolbox</title>
+    <style type="text/css">
+
+        BODY {
+		background: #292638;
+        }
+
+	h1, h2 {
+		font-family: 'PT Serif', serif;
+		border-bottom: 1px solid grey;
+		padding-bottom: 5px;
+	}
+
+	h1 {
+		border-top: 1px solid grey;
+		padding-top: 5px;
+		font-size: 30px;
+	}
+
+	h2 {
+		font-size: 24px;
+	}
+
+        div#index {
+                position: fixed;
+	        padding: 10px 15px 10px;
+		background: #FFFFFF;
+                width: 10%;
+        }
+
+        div#body {
+	        width: 60%;
+	        padding: 10px 15px 10px;
+		background: #FFFFFF;
+        }
+
+	.github {
+		padding: 3px;
+		color: white;
+		border-radius: 5px;
+		background: url(./imgs/GitHub-Mark-Light-64px.png) no-repeat 2% 50% #33f;
+		background-size: 12%;
+		padding-left: 25px;
+	}
+
+        div A {
+        }
+
+        div A:visited {
+        }
+
+        div A:hover {
+        }
+
+	.code {
+		border: 1px solid black;
+		background: #DDDDDD;
+	}
+
+	.alert {
+		border: 5px solid red;
+		padding-top: 5px;
+		font-size: 24px;
+	}
+
+	code {
+	}
+
+	img, object {
+        	max-width: 100%;
+	}
+
+    </style>
+  </head>
+  <body>
+    <center>
+    <p>
+    <div id="body" align="left">
+	<img src="./imgs/banner.png" width="100%"><p>
+      <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
+	<p>
+    <div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a></div>
+
+<hr>
+
+	<small>
+	<p>
+	<div id="fig">
+	<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
+	<strong>Figure:</strong> Simulated MRI images.
+	</div>
+
+
+	<h2>List of Features</h2>
+	<p>
+	<ul>
+	<li>basic features:
+		<ul>
+		<li>runs on Linux and Mac OS X</li>
+		<li>multi-dimensional operations on arrays</li>
+		<li>fast non-uniform Fourier Transform (nuFFT and convolution-based method)</li>
+		<li>multi-dimensional (divergence-free) wavelet transform</li>
+		<li>parallel computation on multiple cores and with <strong>Graphical Processing Units (GPU)</strong></li>
+		</ul>
+	</li>
+	<li>iterative methods:
+		<ul>
+		<li>Conjugate Gradients (CG)</li>
+		<li>(Fast) Iterative Soft-Thresholding Algorithm (ISTA and FISTA)</li>
+		<li>Normalized iterative hard thresholding (NIHT)</li>
+		<li><strong>Alternating Direction Method of Multipliers (ADMM)</strong></li>
+		<li>Iteratively Regularized Gauss-Newton Method (IRGNM)</li>
+		<li>Chambolle-Pock primal-dual algorithm</li>
+		</ul>
+	</li>
+	<li>calibration methods:
+		<ul>
+		<li>direct calibration of coil sensitivities from k-space center</li>
+		<li>Walsh's method for calibration of coil sensitivities</li>
+		<li><strong>ESPIRiT</strong></li>
+		<li>(geometric) channel compression and whitening</li>
+		<li><strong>RING:</strong> estimation of gradient delays for radial MRI</li>
+		</ul>
+	</li>
+	<li>reconstruction methods for MRI:
+		<ul>
+		<li>iterative parallel imaging reconstruction: POCSENSE, SENSE</li>
+		<li><strong>compressed sensing and parallel imaging</strong></li>
+		<li>calibration-less parallel imaging: NLINV and <strong>ENLIVE</strong> (non-linear optimization) and SAKE (structured low-rank matrix completion)</li>
+		<li>reconstruction with <strong>linear subspace constraints</strong></li>
+		<li><strong>non-linear model-based reconstruction</strong> for T1, T2, flow, and water-fat mapping</li>
+		<li>methods based on <strong>deep learning</strong>: variational networks and MoDL</li>
+		</ul>
+	</li>
+	<li>regularization (in arbitrary dimensions):
+		<ul>
+		<li>Tikhonov</li>
+		<li>total variation</li>
+		<li>l1-wavelet</li>
+		<li>(multi-scale) low-rank</li>
+		<li>Tensorflow-based priors</li>
+		</ul>
+	</li>
+	</ul>
+	</p>
+
+    </center>
+  </body>
+</html>

--- a/features.html
+++ b/features.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">tutorials</a>,  <a href="./features.html">list of features</a>,  <a href="./publications.html">referencess & reproducibility</a>   </div>
+    <div>Quick links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
 <hr>
 

--- a/features.html
+++ b/features.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a></div>
+    <div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">tutorials</a>,  <a href="./features.html">list of features</a>,  <a href="./publications.html">referencess & reproducibility</a>   </div>
 
 <hr>
 

--- a/features.html
+++ b/features.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+    <div>Quick Links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
 <hr>
 

--- a/features.html
+++ b/features.html
@@ -85,6 +85,8 @@
 	<p>
     <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
+
+
 <hr>
 
 	<small>

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick Links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+    <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
     <p>
   	<div id="fig">

--- a/index.html
+++ b/index.html
@@ -78,23 +78,21 @@
   </head>
   <body>
     <center>
-    <p>
-    <div id="body" align="left">
+	    <div id="body" align="left">
 	<img src="./imgs/banner.png" width="100%"><p>
-      <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
-	<p>
-    <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
+<h1>BART hands-on material: tutorials, workshops & webinars</h1>
 
-
-
-    <p>
-  	<div id="fig">
-  	<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
-  	<strong>Figure:</strong> Simulated MRI images.
-  	</div>
-
+<div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
 
 <hr>
+
+
+<p>
+<div id="fig">
+<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
+<strong>Figure:</strong> Simulated MRI images.
+</div>
+
 
 	<div>The Berkeley Advanced Reconstruction Toolbox (BART) toolbox is a free and open-source image-reconstruction
 framework for <strong>Computational Magnetic Resonance Imaging</strong> developed by the research groups of

--- a/index.html
+++ b/index.html
@@ -96,10 +96,7 @@
   	</div>
 
 
-
 <hr>
-
-
 
 	<div>The Berkeley Advanced Reconstruction Toolbox (BART) toolbox is a free and open-source image-reconstruction
 framework for <strong>Computational Magnetic Resonance Imaging</strong> developed by the research groups of
@@ -124,7 +121,6 @@ as efficient implementations of many calibration and reconstruction algorithms f
   <h2>Webinar and Workshop Materials with Examples</h2>
 
   <div>Please see our <a href="./tutorials.html">tutorials</a> page, which contains links to the webinars, workshops and other materials.</div>
-
 
 
   <p>

--- a/index.html
+++ b/index.html
@@ -83,16 +83,14 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+    <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
 
 
 
     <p>
   	<div id="fig">
   	<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
-      <small>
   	<strong>Figure:</strong> Simulated MRI images.
-  </small>
   	</div>
 
 

--- a/index.html
+++ b/index.html
@@ -83,7 +83,15 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a></div>
+    <div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">tutorials</a>,  <a href="./features.html">list of features</a>,  <a href="./publications.html">referencess & reproducibility</a>   </div>
+
+    <p>
+  	<div id="fig">
+  	<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
+      <small>
+  	<strong>Figure:</strong> Simulated MRI images.
+  </small>
+  	</div>
 
 <hr>
 
@@ -97,11 +105,6 @@ The command-line tools provide direct access to basic operations on multi-dimens
 as efficient implementations of many calibration and reconstruction algorithms for <strong>parallel imaging and compressed sensing</strong>.
 	</div>
 	<small>
-	<p>
-	<div id="fig">
-	<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
-	<strong>Figure:</strong> Simulated MRI images.
-	</div>
 
 
 
@@ -123,51 +126,15 @@ as efficient implementations of many calibration and reconstruction algorithms f
 
 
 
+  <p>
 
-	<h2>Reproducible Research</h2>
-	<p>
-	This is a list of research paper which can be reproduced using BART.
-	</p>
-	<ul>
-	<li>Xiaoqing Wang, Zhengguo Tan, Nick Scholand, Volkert Roeloffs, Martin Uecker. <a href="https://royalsocietypublishing.org/doi/10.1098/rsta.2020.0196">Physics-based Reconstruction Methods for Magnetic Resonance Imaging.</a> Philos. Trans. R. Soc. A. 379:20200196 (2021) <a class="github" href="https://github.com/mrirecon/physics-recon">GitHub repository</a></li>
-	<li>Xiaoqing Wang, Sebastian Rosenzweig, Nick Scholand, H. Christian M. Holme, Martin Uecker. <a href="https://onlinelibrary.wiley.com/doi/10.1002/mrm.28497">Model-based Reconstruction for Simultaneous Multi-slice T1 Mapping using Single-shot Inversion-recovery Radial FLASH.</a> Magnetic Resonance in Medicine 85:1258-1271 (2021) <a class="github" href="https://github.com/mrirecon/sms-t1-mapping">GitHub repository</a></li>
-	<li>Sebastian Rosenzweig, Nick Scholand, H. Christian M. Holme, Martin Uecker.
-	<a href="https://ieeexplore.ieee.org/document/9057630">Cardiac and Respiratory Self-Gating in Radial MRI using an Adapted Singular Spectrum Analysis (SSA-FARY).</a> IEEE Transactions on Medical Imaging ;39:3029-3041 (2020) <a class="github" href="https://github.com/mrirecon/SSA-FARY">GitHub repository</a></li>
-	<li>Xiaoqing Wang, Florian Kohler, Christina Unterberg-Buchwald, Joachim Lotz, Jens Frahm, Martin Uecker.
-	<a href="https://jcmr-online.biomedcentral.com/articles/10.1186/s12968-019-0570-3">Model-based myocardial T1 mapping with sparsity constraints using single-shot inversion-recovery radial FLASH cardiovascular magnetic resonance.</a> Journal of Cardiovascular Magnetic Resonance 21:60 (2019) <a class="github" href="https://github.com/mrirecon/myocardial-t1-mapping">GitHub repository</a></li>
-	<li>Sebastian Rosenzweig, H. Christian M. Holme, Martin Uecker.
-	<a href="https://onlinelibrary.wiley.com/doi/10.1002/mrm.27506">Simple Auto-Calibrated Gradient Delay Estimation From Few Spokes Using Radial Intersections (RING)</a>. Magnetic Resonance in Medicine 81:1898-1906 (2019) <a class="github" href="https://github.com/mrirecon/ring">GitHub repository</a></li>
-	<li>H. Christian M. Holme, Sebastian Rosenzweig, Frank Ong, Robin N. Wilke, Michael Lustig, Martin Uecker.
-	<a href="https://www.nature.com/articles/s41598-019-39888-7">ENLIVE: An Efficient Nonlinear Method for Calibrationless and Robust Parallel Imaging.</a> Scientific Reports 9:3034 (2019) <a class="github" href="https://github.com/mrirecon/enlive">GitHub repository</a></li>
-	<li>Sebastian Rosenzweig, H. Christian M. Holme, Robin N. Wilke, Dirk Voit, Jens Frahm, Martin Uecker. <a href="http://onlinelibrary.wiley.com/doi/10.1002/mrm.26878/abstract">Simultaneous Multi-Slice Reconstruction Using Regularized Nonlinear Inversion: SMS-NLINV.<a> Magnetic Resonance in Medicine 79:2057-2066 (2018) <a class="github" href="https://github.com/mrirecon/sms-nlinv">GitHub repository</a></li>
-	<li>Martin Uecker and Michael Lustig. <a href="http://onlinelibrary.wiley.com/doi/10.1002/mrm.26191/abstract">Estimating Absolute-Phase Maps Using ESPIRiT and Virtual Conjugate Coils.</a> Magnetic Resonance in Medicine 77:1201-1207 (2017) <a class="github" href="https://github.com/mrirecon/vcc-espirit">GitHub repository</a></li>
-	</ul>
-	<h2>References</h2>
-	<p>
-	A a generic reference (all versions): BART Toolbox for Computational Magnetic Resonance Imaging, DOI: 10.5281/zenodo.592960
-	<p>
-	<ul>
-	<li>Moritz Blumenthal and Martin Uecker. <a href="https://index.mirasmart.com/ISMRM2021/PDFfiles/1754.html">Deep, Deep Learning with BART.</a> ISMRM Annual Meeting 2021, In Proc. Intl. Soc. Mag. Reson. Med. 29;1754 (2021)</li>
-	<li>Guanxiong Luo, Moritz Blumenthal, Martin Uecker. <a href="https://index.mirasmart.com/ISMRM2021/PDFfiles/1756.html">Using data-driven image priors for image reconstruction with BART.</a> ISMRM Annual Meeting 2021, In Proc. Intl. Soc. Mag. Reson. Med. 29;1756 (2021)</li>
-	<li>H. Christian M. Holme and Martin Uecker. <a href="https://index.mirasmart.com/ISMRM2021/PDFfiles/3768.html">Reproducibility meets Software Testing: Automatic Tests of Reproducible Publications Using BART.</a> ISMRM Annual Meeting 2021, In Proc. Intl. Soc. Mag. Reson. Med. 29;3768 (2021)</li>
-	<li>Martin Uecker. <a href="http://indexsmart.mirasmart.com/ISMRM2018/PDFfiles/2802.html">Machine Learning Using the BART Toolbox - Implementation of a Deep Convolutional Neural Network for Denoising.</a> Joint Annual Meeting ISMRM-ESMRMB, Paris 2018, In Proc. Intl. Soc. Mag. Reson. Med. 26;2802</li>
-	<li>Jonathan I Tamir, Frank Ong, Joseph Y Cheng, Martin Uecker, and Michael Lustig. <a href="https://www.gwdg.de/~muecker1/sedona16-bart.pdf">Generalized Magnetic Resonance Image Reconstruction using The Berkeley Advanced Reconstruction Toolbox</a>. <a href="http://www.ismrm.org/workshops/Data16/">ISMRM Workshop on Data Sampling and Image Reconstruction</a>, Sedona 2016
-	<li>Martin Uecker, Frank Ong, Jonathan I Tamir, Dara Bahri, Patrick Virtue, Joseph Y Cheng, Tao Zhang, and Michael Lustig.
-<a href="http://index.mirasmart.com/ismrm2015/PDFfiles/2486.pdf">Berkeley Advanced Reconstruction Toolbox</a>. Annual Meeting ISMRM, Toronto 2015, In Proc. Intl. Soc. Mag. Reson. Med. 23:2486
-	<li>Martin Uecker, Patrick Virtue, Frank Ong, Mark J. Murphy, Marcus T. Alley, Shreyas S. Vasanawala, and Michael Lustig. <a href="https://www.gwdg.de/~muecker1/toolbox.pdf">Software Toolbox and Programming Library for Compressed Sensing and Parallel Imaging</a>. <a href="https://www.ismrm.org/workshops/Data13/">ISMRM Workshop on Data Sampling and Image Reconstruction</a>, Sedona 2013
-	<li>Martin Uecker, Peng Lai, Mark J. Murphy, Patrick Virtue, Michael Elad, John M. Pauly, Shreyas S. Vasanawala, and Michael Lustig. <a href="http://onlinelibrary.wiley.com/doi/10.1002/mrm.24751/abstract">ESPIRiT - An Eigenvalue Approach to Autocalibrating Parallel MRI: Where SENSE meets GRAPPA</a>. Magnetic Resonance in Medicine, 71:990-1001 (2014)
-	</ul>
-	</small>
+  <h2 id="acknowledgements">Acknowledgements</h2>
+  <p>This work is supported by NIH Grant U24EB029240-01.</p>
+  <hr />
+  </p>
+
+
       </div>
     </center>
-
-
-<h2 id="acknowledgements">Acknowledgements</h2>
-<p>This work is supported by NIH Grant U24EB029240-01.</p>
-<hr />
-</p>
-	</div>
-    </center>
-
-</body>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">tutorials</a>,  <a href="./features.html">list of features</a>,  <a href="./publications.html">referencess & reproducibility</a>   </div>
+    <div>Quick links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
     <p>
   	<div id="fig">

--- a/index.html
+++ b/index.html
@@ -102,9 +102,11 @@ as efficient implementations of many calibration and reconstruction algorithms f
 
   <h2>BART Hands-on Material - Get Started and Find Help </h2>
 
-  <div>Our new bart hands-on material page contains BART documentary and educational materials that were
+  <div>Our new bart <a href="./tutorials.html">hands-on material</a> page contains BART documentary and educational materials that were
       published over the last few years in tutorials, workshops and online webinars. They are organized by topic, from a new-user level to advanced material.
   </div>
+
+
 
 
 	<h2>List of Features</h2>

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+    <div>Quick Links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
     <p>
   	<div id="fig">

--- a/index.html
+++ b/index.html
@@ -106,11 +106,6 @@ arrays, Fourier and wavelet transforms, as well as generic implementations of it
 The command-line tools provide direct access to basic operations on multi-dimensional arrays as well
 as efficient implementations of many calibration and reconstruction algorithms for <strong>parallel imaging and compressed sensing</strong>.
 	</div>
-	<small>
-
-
-
-
 
   </p>
 	<h2 class="header">Mailing List</h2>

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick links:  <a href="./tutorials.html">Tutorials</a>, <a href="./Installation.html">Installation</a></div>
+    <div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a></div>
 
 <hr>
 
@@ -116,48 +116,14 @@ as efficient implementations of many calibration and reconstruction algorithms f
 	<p>
 	(or contact the main author: martin.uecker at med.uni-goettingen.de)
 	<p>
-	<h2>Download</h2>
-	<p>
-	<strong>Note:</strong> The software is intended for research use only
-	and <strong>NOT FOR DIAGNOSTIC USE</strong>. It comes without any
-	warranty (see LICENSE for details).
-	<p>
-	<strong>Releases:</strong>
-	<p>
-	It is recommended to download the latest release. All releases can be found <a href="http://github.com/mrirecon/bart/releases/">here</a>.<br>
-	<p>
-	Selected releases:
-	<ul>
-	<li><a href="https://github.com/mrirecon/bart/releases/tag/v0.7.00">bart: version 0.7.00 (2021)</a> <a href="http://dx.doi.org/10.5281/zenodo.4570601"><img src="./imgs/zenodo/zenodo.4570601.svg" alt="DOI: 10.5281/zenodo.4570601"></a>
-	<li><a href="https://github.com/mrirecon/bart/releases/tag/v0.6.00">bart: version 0.6.00 (2020)</a> <a href="http://dx.doi.org/10.5281/zenodo.3934312"><img src="./imgs/zenodo/zenodo.3934312.svg" alt="DOI: 10.5281/zenodo.3934312"></a>
-	<li><a href="https://github.com/mrirecon/bart/releases/tag/v0.4.04">bart: version 0.4.04 (2018)</a> <a href="http://dx.doi.org/10.5281/zenodo.2149128"><img src="./imgs/zenodo/zenodo.2149128.svg" alt="DOI: 10.5281/zenodo.2149128"></a>
-	<li><a href="https://github.com/mrirecon/bart/releases/tag/v0.2.08">bart: version 0.2.08 (2015)</a> <a href="http://dx.doi.org/10.5281/zenodo.18041"><img src="./imgs/zenodo/zenodo.18041.svg" alt="DOI: 10.5281/zenodo.18041"></a>
-	</ul>
-	<p>BART has also been included in <a href="https://www.debian.org/">Debian GNU/Linux</a> (and Ubuntu). The
-	Debian binary package can be <a href="https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/bart.html">reproducibly built</a>
-	from the source code (as distributed by Debian) and can be downloaded from <a href="https://packages.debian.org/sid/bart">here</a>. There is also a<a href="https://packages.debian.org/sid/bart-view"> package</a> for the image viewer. We also provide unofficial packages for Fedora and CentOS: <a href="https://copr.fedorainfracloud.org/coprs/schaten/bart/package/bart/"><img src="https://copr.fedorainfracloud.org/coprs/schaten/bart/package/bart/status_image/last_build.png" /></a>.
-	<p>
-	Please note that running BART on Windows is not supported. Nevertheless, some versions of BART are reported to work on Windows using WSL or Cygwin.
-	<p>
-	For developers: the C source code can be found in the  <a class="github" href="https://github.com/mrirecon/bart">GitHub repository</a>
-
-
 
   <h2>Webinar and Workshop Materials with Examples</h2>
-	<h3>Webinars</h3>
-	<p>
-	There are new tutorials from our Webinar which you can find in a <a class="github" href="https://github.com/mrirecon/bart-webinars">GitHub repository</a>.
-	</p>
 
-	<h3>Workshops</h3>
-	<p> <b>ISMRM 2021</b> As part of the ISMRM 2021 meeting, we gave a <a href="./ismrm21.html">demo of the new features of BART related to non-linear model-based reconstruction and deep learning integration.</a>
-	</p>
-	<p>
-	<b>ISMRM 2016</b> The toolbox was presented at the <a href="http://www.ismrm.org/workshops/Data16/">ISMRM 2016 Data Sampling and Image Reconstruction Workshop</a>. This material was created for BART version 0.3.00 and later versions might have minor differences. Please check the README included with each release for up-to-date installation instructions.
-	</p>
-	<p>
-	Demo code and data: <a class="github" href="https://github.com/mrirecon/bart-workshop">GitHub repository</a>
-	<p>
+  <div>Please see our <a href="./tutorials.html">tutorials</a> page, which contains links to the webinars, workshops and other materials.</div>
+
+
+
+
 	<h2>Reproducible Research</h2>
 	<p>
 	This is a list of research paper which can be reproduced using BART.
@@ -194,5 +160,14 @@ as efficient implementations of many calibration and reconstruction algorithms f
 	</small>
       </div>
     </center>
-  </body>
+
+
+<h2 id="acknowledgements">Acknowledgements</h2>
+<p>This work is supported by NIH Grant U24EB029240-01.</p>
+<hr />
+</p>
+	</div>
+    </center>
+
+</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     <center>
 	    <div id="body" align="left">
 	<img src="./imgs/banner.png" width="100%"><p>
-<h1>BART hands-on material: tutorials, workshops & webinars</h1>
+<h1>BART Hands-on Material: Tutorials, Workshops & Webinars</h1>
 
 <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
 
@@ -119,8 +119,32 @@ as efficient implementations of many calibration and reconstruction algorithms f
   <div>Please see our <a href="./tutorials.html">tutorials</a> page, which contains links to the webinars, workshops and other materials.</div>
 
 
+  <h2>Quick Example</h2>
   <p>
+  Perform ESPIRiT calibration and image reconstruction with
+  l1-wavelet regularization:
+  </p>
+  <div class="code">
+  <code>
+  <p>
+  &nbsp;$ bart ecalib kspace sensitivities<br>
+  &nbsp;$ bart pics -l1 -r0.001 kspace sensitivities image_out
+  </p>
+  </code>
+  </div>
+  <p>
+  A python-based image viewer (bartview.py) which can read the
+  BART data format is included in the source repository.<br>
+  </p>
+  <p>
+  An image viewer for Linux and Mac OS X can be found
+  <a href="https://github.com/mrirecon/view">here</a>.
+  </p>
+  <p>
+  You can try BART directly in your browser: <a href="https://mybinder.org/v2/gh/mrirecon/bart-binder/v0.7.00?filepath=example.ipynb"><img src="./imgs/binder.svg" alt="binder"></a>
 
+
+  <p>
   <h2 id="acknowledgements">Acknowledgements</h2>
   <p>This work is supported by NIH Grant U24EB029240-01.</p>
   <hr />

--- a/index.html
+++ b/index.html
@@ -99,6 +99,14 @@ as efficient implementations of many calibration and reconstruction algorithms f
 	<strong>Figure:</strong> Simulated MRI images.
 	</div>
 	</p>
+
+  <h2>BART Hands-on Material - Get Started and Find Help </h2>
+
+  <div>Our new bart hands-on material page contains BART documentary and educational materials that were
+      published over the last few years in tutorials, workshops and online webinars. They are organized by topic, from a new-user level to advanced material.
+  </div>
+
+
 	<h2>List of Features</h2>
 	<p>
 	<ul>
@@ -245,12 +253,16 @@ as efficient implementations of many calibration and reconstruction algorithms f
 	Matlab code and data: <a class="github" href="https://github.com/mikgroup/espirit-matlab-examples">GitHub repository</a>
 	<p>
 	A Matlab-based image viewer which works well with BART is <a href="http://www.biomednmr.mpg.de/index.php?option=com_content&task=view&id=137&Itemid=43">arrayShow</a> by Tilman Sumpf.
-	<h2>Webinar and Workshop Materials with Examples</h2>
+
+
+
+
+  <h2>Webinar and Workshop Materials with Examples</h2>
 	<h3>Webinars</h3>
 	<p>
 	There are new tutorials from our Webinar which you can find in a <a class="github" href="https://github.com/mrirecon/bart-webinars">GitHub repository</a>.
 	</p>
-	
+
 	<h3>Workshops</h3>
 	<p> <b>ISMRM 2021</b> As part of the ISMRM 2021 meeting, we gave a <a href="./ismrm21.html">demo of the new features of BART related to non-linear model-based reconstruction and deep learning integration.</a>
 	</p>

--- a/index.html
+++ b/index.html
@@ -85,6 +85,8 @@
 	<p>
     <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
+
+
     <p>
   	<div id="fig">
   	<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>

--- a/index.html
+++ b/index.html
@@ -83,6 +83,10 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
+    <div>Quick links:  <a href="./tutorials.html">Tutorials</a>, <a href="./Installation.html">Installation</a></div>
+
+<hr>
+
 	<div>The Berkeley Advanced Reconstruction Toolbox (BART) toolbox is a free and open-source image-reconstruction
 framework for <strong>Computational Magnetic Resonance Imaging</strong> developed by the research groups of
 <a href="http://wwwuser.gwdg.de/~muecker1/">Martin Uecker</a> (Graz University of Technology), <a href="http://users.ece.utexas.edu/~jtamir/">Jon Tamir</a> (UT Austin), and
@@ -98,93 +102,12 @@ as efficient implementations of many calibration and reconstruction algorithms f
 	<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
 	<strong>Figure:</strong> Simulated MRI images.
 	</div>
-	</p>
-
-  <h2>BART Hands-on Material - Get Started and Find Help </h2>
-
-  <div>Our new bart <a href="./tutorials.html">hands-on material</a> page contains BART documentary and educational materials that were
-      published over the last few years in tutorials, workshops and online webinars. They are organized by topic, from a new-user level to advanced material.
-  </div>
 
 
 
 
-	<h2>List of Features</h2>
-	<p>
-	<ul>
-	<li>basic features:
-		<ul>
-		<li>runs on Linux and Mac OS X</li>
-		<li>multi-dimensional operations on arrays</li>
-		<li>fast non-uniform Fourier Transform (nuFFT and convolution-based method)</li>
-		<li>multi-dimensional (divergence-free) wavelet transform</li>
-		<li>parallel computation on multiple cores and with <strong>Graphical Processing Units (GPU)</strong></li>
-		</ul>
-	</li>
-	<li>iterative methods:
-		<ul>
-		<li>Conjugate Gradients (CG)</li>
-		<li>(Fast) Iterative Soft-Thresholding Algorithm (ISTA and FISTA)</li>
-		<li>Normalized iterative hard thresholding (NIHT)</li>
-		<li><strong>Alternating Direction Method of Multipliers (ADMM)</strong></li>
-		<li>Iteratively Regularized Gauss-Newton Method (IRGNM)</li>
-		<li>Chambolle-Pock primal-dual algorithm</li>
-		</ul>
-	</li>
-	<li>calibration methods:
-		<ul>
-		<li>direct calibration of coil sensitivities from k-space center</li>
-		<li>Walsh's method for calibration of coil sensitivities</li>
-		<li><strong>ESPIRiT</strong></li>
-		<li>(geometric) channel compression and whitening</li>
-		<li><strong>RING:</strong> estimation of gradient delays for radial MRI</li>
-		</ul>
-	</li>
-	<li>reconstruction methods for MRI:
-		<ul>
-		<li>iterative parallel imaging reconstruction: POCSENSE, SENSE</li>
-		<li><strong>compressed sensing and parallel imaging</strong></li>
-		<li>calibration-less parallel imaging: NLINV and <strong>ENLIVE</strong> (non-linear optimization) and SAKE (structured low-rank matrix completion)</li>
-		<li>reconstruction with <strong>linear subspace constraints</strong></li>
-		<li><strong>non-linear model-based reconstruction</strong> for T1, T2, flow, and water-fat mapping</li>
-		<li>methods based on <strong>deep learning</strong>: variational networks and MoDL</li>
-		</ul>
-	</li>
-	<li>regularization (in arbitrary dimensions):
-		<ul>
-		<li>Tikhonov</li>
-		<li>total variation</li>
-		<li>l1-wavelet</li>
-		<li>(multi-scale) low-rank</li>
-		<li>Tensorflow-based priors</li>
-		</ul>
-	</li>
-	</ul>
-	</p>
-	<h2>Example</h2>
-	<p>
-	Perform ESPIRiT calibration and image reconstruction with
-	l1-wavelet regularization:
-	</p>
-	<div class="code">
-	<code>
-	<p>
-	&nbsp;$ bart ecalib kspace sensitivities<br>
-	&nbsp;$ bart pics -l1 -r0.001 kspace sensitivities image_out
-	</p>
-	</code>
-	</div>
-	<p>
-	A python-based image viewer (bartview.py) which can read the
-	BART data format is included in the source repository.<br>
-	</p>
-	<p>
-	An image viewer for Linux and Mac OS X can be found
-	<a href="https://github.com/mrirecon/view">here</a>.
-	</p>
-	<p>
-	You can try BART directly in your browser: <a href="https://mybinder.org/v2/gh/mrirecon/bart-binder/v0.7.00?filepath=example.ipynb"><img src="./imgs/binder.svg" alt="binder"></a>
-	</p>
+
+  </p>
 	<h2 class="header">Mailing List</h2>
 	<p>
 	Please direct all questions or comments to the public mailing list:
@@ -217,45 +140,6 @@ as efficient implementations of many calibration and reconstruction algorithms f
 	Please note that running BART on Windows is not supported. Nevertheless, some versions of BART are reported to work on Windows using WSL or Cygwin.
 	<p>
 	For developers: the C source code can be found in the  <a class="github" href="https://github.com/mrirecon/bart">GitHub repository</a>
-	<h2>Installation</h2>
-	<p>Installation of the required libraries, downloading and unpacking of the archive, and
-	compilation on Linux is usually as simple as typing the following commands:
-	<div class="code">
-	<code>
-	<p>
-	&nbsp;$ sudo apt-get install make gcc libfftw3-dev liblapacke-dev libpng-dev libopenblas-dev<br>
-	&nbsp;$ wget https://github.com/mrirecon/bart/archive/vX.Y.ZZ.tar.gz<br>
-	&nbsp;$ tar xzvf vX.YY.ZZ.tar.gz<br>
-	&nbsp;$ cd bart-X.YY.ZZ<br>
-	&nbsp;$ make
-	</p>
-	</code>
-	</div>
-	<p>
-	See the README file included with the source code for further instructions and for Mac OS X and Windows.
-	</p>
-	<p>
-	If you are a Docker user you can also start with this extremely simple <a href="./Dockerfile">Dockerfile</a>.
-	</p>
-	<h2>Matlab Interface and Examples</h2>
-	<p>
-	The toolbox can also be used in combination with Matlab/Octave.
-	</p>
-	<div class="code">
-	<code>
-	<p>
-	&nbsp;&gt;&gt;&nbsp;sensitivities = bart('ecalib', kspace);<br>
-	&nbsp;&gt;&gt;&nbsp;image_out = bart('pics -l1 -r0.001', kspace, sensitivities);
-	</code>
-	</div>
-	<p>
-	More examples where the tools are called
-	directly from Matlab can be found <a href="./examples.html">here</a>.
-	<p>
-	Matlab code and data: <a class="github" href="https://github.com/mikgroup/espirit-matlab-examples">GitHub repository</a>
-	<p>
-	A Matlab-based image viewer which works well with BART is <a href="http://www.biomednmr.mpg.de/index.php?option=com_content&task=view&id=137&Itemid=43">arrayShow</a> by Tilman Sumpf.
-
 
 
 

--- a/index.html
+++ b/index.html
@@ -95,7 +95,11 @@
   </small>
   	</div>
 
+
+
 <hr>
+
+
 
 	<div>The Berkeley Advanced Reconstruction Toolbox (BART) toolbox is a free and open-source image-reconstruction
 framework for <strong>Computational Magnetic Resonance Imaging</strong> developed by the research groups of

--- a/installation.html
+++ b/installation.html
@@ -80,7 +80,7 @@
     <center>
 	    <div id="body" align="left">
 	<img src="./imgs/banner.png" width="100%"><p>
-<h1>BART hands-on material: tutorials, workshops & webinars</h1>
+<h1>BART Hands-on Material: Tutorials, Workshops & Webinars</h1>
 
 <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
 

--- a/installation.html
+++ b/installation.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick Links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+    <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
 <hr>
 

--- a/installation.html
+++ b/installation.html
@@ -78,26 +78,20 @@
   </head>
   <body>
     <center>
-    <p>
-    <div id="body" align="left">
+	    <div id="body" align="left">
 	<img src="./imgs/banner.png" width="100%"><p>
-      <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
-	<p>
-    <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
+<h1>BART hands-on material: tutorials, workshops & webinars</h1>
 
-
+<div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
 
 <hr>
 
 
-  <p>
-  <div id="fig">
-  <img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
-  <strong>Figure:</strong> Simulated MRI images.
-  </div>
-
-
-
+<p>
+<div id="fig">
+<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
+<strong>Figure:</strong> Simulated MRI images.
+</div>
 
 <h2>Download</h2>
 <p>

--- a/installation.html
+++ b/installation.html
@@ -97,6 +97,9 @@
   </div>
 
 </small>
+
+
+
 <h2>Download</h2>
 <p>
 <strong>Note:</strong> The software is intended for research use only

--- a/installation.html
+++ b/installation.html
@@ -96,6 +96,7 @@
   <strong>Figure:</strong> Simulated MRI images.
   </div>
 
+</small>
 <h2>Download</h2>
 <p>
 <strong>Note:</strong> The software is intended for research use only
@@ -144,7 +145,7 @@ For developers: the C source code can be found in the  <a class="github" href="h
 	</p>
 
 
-	</small>
+
       </div>
     </center>
   </body>

--- a/installation.html
+++ b/installation.html
@@ -1,0 +1,118 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="de">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+    <title>BART Toolbox</title>
+    <style type="text/css">
+
+        BODY {
+		background: #292638;
+        }
+
+	h1, h2 {
+		font-family: 'PT Serif', serif;
+		border-bottom: 1px solid grey;
+		padding-bottom: 5px;
+	}
+
+	h1 {
+		border-top: 1px solid grey;
+		padding-top: 5px;
+		font-size: 30px;
+	}
+
+	h2 {
+		font-size: 24px;
+	}
+
+        div#index {
+                position: fixed;
+	        padding: 10px 15px 10px;
+		background: #FFFFFF;
+                width: 10%;
+        }
+
+        div#body {
+	        width: 60%;
+	        padding: 10px 15px 10px;
+		background: #FFFFFF;
+        }
+
+	.github {
+		padding: 3px;
+		color: white;
+		border-radius: 5px;
+		background: url(./imgs/GitHub-Mark-Light-64px.png) no-repeat 2% 50% #33f;
+		background-size: 12%;
+		padding-left: 25px;
+	}
+
+        div A {
+        }
+
+        div A:visited {
+        }
+
+        div A:hover {
+        }
+
+	.code {
+		border: 1px solid black;
+		background: #DDDDDD;
+	}
+
+	.alert {
+		border: 5px solid red;
+		padding-top: 5px;
+		font-size: 24px;
+	}
+
+	code {
+	}
+
+	img, object {
+        	max-width: 100%;
+	}
+
+    </style>
+  </head>
+  <body>
+    <center>
+    <p>
+    <div id="body" align="left">
+	<img src="./imgs/banner.png" width="100%"><p>
+      <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
+	<p>
+    <div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a></div>
+
+<hr>
+
+
+
+  <h2>Installation</h2>
+	<p>Installation of the required libraries, downloading and unpacking of the archive, and
+	compilation on Linux is usually as simple as typing the following commands:
+	<div class="code">
+	<code>
+	<p>
+	&nbsp;$ sudo apt-get install make gcc libfftw3-dev liblapacke-dev libpng-dev libopenblas-dev<br>
+	&nbsp;$ wget https://github.com/mrirecon/bart/archive/vX.Y.ZZ.tar.gz<br>
+	&nbsp;$ tar xzvf vX.YY.ZZ.tar.gz<br>
+	&nbsp;$ cd bart-X.YY.ZZ<br>
+	&nbsp;$ make
+	</p>
+	</code>
+	</div>
+	<p>
+	See the README file included with the source code for further instructions and for Mac OS X and Windows.
+	</p>
+	<p>
+	If you are a Docker user you can also start with this extremely simple <a href="./Dockerfile">Dockerfile</a>.
+	</p>
+
+
+	</small>
+      </div>
+    </center>
+  </body>
+</html>

--- a/installation.html
+++ b/installation.html
@@ -83,10 +83,41 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a></div>
+    <div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">tutorials</a>,  <a href="./features.html">list of features</a>,  <a href="./publications.html">referencess & reproducibility</a>   </div>
 
 <hr>
 
+<small>
+  <p>
+  <div id="fig">
+  <img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
+  <strong>Figure:</strong> Simulated MRI images.
+  </div>
+
+<h2>Download</h2>
+<p>
+<strong>Note:</strong> The software is intended for research use only
+and <strong>NOT FOR DIAGNOSTIC USE</strong>. It comes without any
+warranty (see LICENSE for details).
+<p>
+<strong>Releases:</strong>
+<p>
+It is recommended to download the latest release. All releases can be found <a href="http://github.com/mrirecon/bart/releases/">here</a>.<br>
+<p>
+Selected releases:
+<ul>
+<li><a href="https://github.com/mrirecon/bart/releases/tag/v0.7.00">bart: version 0.7.00 (2021)</a> <a href="http://dx.doi.org/10.5281/zenodo.4570601"><img src="./imgs/zenodo/zenodo.4570601.svg" alt="DOI: 10.5281/zenodo.4570601"></a>
+<li><a href="https://github.com/mrirecon/bart/releases/tag/v0.6.00">bart: version 0.6.00 (2020)</a> <a href="http://dx.doi.org/10.5281/zenodo.3934312"><img src="./imgs/zenodo/zenodo.3934312.svg" alt="DOI: 10.5281/zenodo.3934312"></a>
+<li><a href="https://github.com/mrirecon/bart/releases/tag/v0.4.04">bart: version 0.4.04 (2018)</a> <a href="http://dx.doi.org/10.5281/zenodo.2149128"><img src="./imgs/zenodo/zenodo.2149128.svg" alt="DOI: 10.5281/zenodo.2149128"></a>
+<li><a href="https://github.com/mrirecon/bart/releases/tag/v0.2.08">bart: version 0.2.08 (2015)</a> <a href="http://dx.doi.org/10.5281/zenodo.18041"><img src="./imgs/zenodo/zenodo.18041.svg" alt="DOI: 10.5281/zenodo.18041"></a>
+</ul>
+<p>BART has also been included in <a href="https://www.debian.org/">Debian GNU/Linux</a> (and Ubuntu). The
+Debian binary package can be <a href="https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/bart.html">reproducibly built</a>
+from the source code (as distributed by Debian) and can be downloaded from <a href="https://packages.debian.org/sid/bart">here</a>. There is also a<a href="https://packages.debian.org/sid/bart-view"> package</a> for the image viewer. We also provide unofficial packages for Fedora and CentOS: <a href="https://copr.fedorainfracloud.org/coprs/schaten/bart/package/bart/"><img src="https://copr.fedorainfracloud.org/coprs/schaten/bart/package/bart/status_image/last_build.png" /></a>.
+<p>
+Please note that running BART on Windows is not supported. Nevertheless, some versions of BART are reported to work on Windows using WSL or Cygwin.
+<p>
+For developers: the C source code can be found in the  <a class="github" href="https://github.com/mrirecon/bart">GitHub repository</a>
 
 
   <h2>Installation</h2>

--- a/installation.html
+++ b/installation.html
@@ -85,6 +85,8 @@
 	<p>
     <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
+
+
 <hr>
 
 <small>

--- a/installation.html
+++ b/installation.html
@@ -83,20 +83,19 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+    <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
 
 
 
 <hr>
 
-<small>
+
   <p>
   <div id="fig">
   <img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
   <strong>Figure:</strong> Simulated MRI images.
   </div>
 
-</small>
 
 
 

--- a/installation.html
+++ b/installation.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">tutorials</a>,  <a href="./features.html">list of features</a>,  <a href="./publications.html">referencess & reproducibility</a>   </div>
+    <div>Quick links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
 <hr>
 

--- a/installation.html
+++ b/installation.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+    <div>Quick Links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
 <hr>
 

--- a/publications.html
+++ b/publications.html
@@ -80,7 +80,7 @@
     <center>
 	    <div id="body" align="left">
 	<img src="./imgs/banner.png" width="100%"><p>
-<h1>BART hands-on material: tutorials, workshops & webinars</h1>
+<h1>BART Hands-on Material: Tutorials, Workshops & Webinars</h1>
 
 <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
 

--- a/publications.html
+++ b/publications.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+    <div>Quick Links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
 <hr>
 <small>

--- a/publications.html
+++ b/publications.html
@@ -1,0 +1,143 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="de">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+    <title>BART Toolbox</title>
+    <style type="text/css">
+
+        BODY {
+		background: #292638;
+        }
+
+	h1, h2 {
+		font-family: 'PT Serif', serif;
+		border-bottom: 1px solid grey;
+		padding-bottom: 5px;
+	}
+
+	h1 {
+		border-top: 1px solid grey;
+		padding-top: 5px;
+		font-size: 30px;
+	}
+
+	h2 {
+		font-size: 24px;
+	}
+
+        div#index {
+                position: fixed;
+	        padding: 10px 15px 10px;
+		background: #FFFFFF;
+                width: 10%;
+        }
+
+        div#body {
+	        width: 60%;
+	        padding: 10px 15px 10px;
+		background: #FFFFFF;
+        }
+
+	.github {
+		padding: 3px;
+		color: white;
+		border-radius: 5px;
+		background: url(./imgs/GitHub-Mark-Light-64px.png) no-repeat 2% 50% #33f;
+		background-size: 12%;
+		padding-left: 25px;
+	}
+
+        div A {
+        }
+
+        div A:visited {
+        }
+
+        div A:hover {
+        }
+
+	.code {
+		border: 1px solid black;
+		background: #DDDDDD;
+	}
+
+	.alert {
+		border: 5px solid red;
+		padding-top: 5px;
+		font-size: 24px;
+	}
+
+	code {
+	}
+
+	img, object {
+        	max-width: 100%;
+	}
+
+    </style>
+  </head>
+  <body>
+    <center>
+    <p>
+    <div id="body" align="left">
+	<img src="./imgs/banner.png" width="100%"><p>
+      <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
+	<p>
+    <div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">tutorials</a>,  <a href="./features.html">list of features</a>,  <a href="./publications.html">referencess & reproducibility</a>   </div>
+
+<hr>
+<small>
+  
+<p>
+<div id="fig">
+<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
+<strong>Figure:</strong> Simulated MRI images.
+</div>
+
+	<h2>Reproducible Research</h2>
+	<p>
+	This is a list of research paper which can be reproduced using BART.
+	</p>
+	<ul>
+	<li>Xiaoqing Wang, Zhengguo Tan, Nick Scholand, Volkert Roeloffs, Martin Uecker. <a href="https://royalsocietypublishing.org/doi/10.1098/rsta.2020.0196">Physics-based Reconstruction Methods for Magnetic Resonance Imaging.</a> Philos. Trans. R. Soc. A. 379:20200196 (2021) <a class="github" href="https://github.com/mrirecon/physics-recon">GitHub repository</a></li>
+	<li>Xiaoqing Wang, Sebastian Rosenzweig, Nick Scholand, H. Christian M. Holme, Martin Uecker. <a href="https://onlinelibrary.wiley.com/doi/10.1002/mrm.28497">Model-based Reconstruction for Simultaneous Multi-slice T1 Mapping using Single-shot Inversion-recovery Radial FLASH.</a> Magnetic Resonance in Medicine 85:1258-1271 (2021) <a class="github" href="https://github.com/mrirecon/sms-t1-mapping">GitHub repository</a></li>
+	<li>Sebastian Rosenzweig, Nick Scholand, H. Christian M. Holme, Martin Uecker.
+	<a href="https://ieeexplore.ieee.org/document/9057630">Cardiac and Respiratory Self-Gating in Radial MRI using an Adapted Singular Spectrum Analysis (SSA-FARY).</a> IEEE Transactions on Medical Imaging ;39:3029-3041 (2020) <a class="github" href="https://github.com/mrirecon/SSA-FARY">GitHub repository</a></li>
+	<li>Xiaoqing Wang, Florian Kohler, Christina Unterberg-Buchwald, Joachim Lotz, Jens Frahm, Martin Uecker.
+	<a href="https://jcmr-online.biomedcentral.com/articles/10.1186/s12968-019-0570-3">Model-based myocardial T1 mapping with sparsity constraints using single-shot inversion-recovery radial FLASH cardiovascular magnetic resonance.</a> Journal of Cardiovascular Magnetic Resonance 21:60 (2019) <a class="github" href="https://github.com/mrirecon/myocardial-t1-mapping">GitHub repository</a></li>
+	<li>Sebastian Rosenzweig, H. Christian M. Holme, Martin Uecker.
+	<a href="https://onlinelibrary.wiley.com/doi/10.1002/mrm.27506">Simple Auto-Calibrated Gradient Delay Estimation From Few Spokes Using Radial Intersections (RING)</a>. Magnetic Resonance in Medicine 81:1898-1906 (2019) <a class="github" href="https://github.com/mrirecon/ring">GitHub repository</a></li>
+	<li>H. Christian M. Holme, Sebastian Rosenzweig, Frank Ong, Robin N. Wilke, Michael Lustig, Martin Uecker.
+	<a href="https://www.nature.com/articles/s41598-019-39888-7">ENLIVE: An Efficient Nonlinear Method for Calibrationless and Robust Parallel Imaging.</a> Scientific Reports 9:3034 (2019) <a class="github" href="https://github.com/mrirecon/enlive">GitHub repository</a></li>
+	<li>Sebastian Rosenzweig, H. Christian M. Holme, Robin N. Wilke, Dirk Voit, Jens Frahm, Martin Uecker. <a href="http://onlinelibrary.wiley.com/doi/10.1002/mrm.26878/abstract">Simultaneous Multi-Slice Reconstruction Using Regularized Nonlinear Inversion: SMS-NLINV.<a> Magnetic Resonance in Medicine 79:2057-2066 (2018) <a class="github" href="https://github.com/mrirecon/sms-nlinv">GitHub repository</a></li>
+	<li>Martin Uecker and Michael Lustig. <a href="http://onlinelibrary.wiley.com/doi/10.1002/mrm.26191/abstract">Estimating Absolute-Phase Maps Using ESPIRiT and Virtual Conjugate Coils.</a> Magnetic Resonance in Medicine 77:1201-1207 (2017) <a class="github" href="https://github.com/mrirecon/vcc-espirit">GitHub repository</a></li>
+	</ul>
+	<h2>References</h2>
+	<p>
+	A a generic reference (all versions): BART Toolbox for Computational Magnetic Resonance Imaging, DOI: 10.5281/zenodo.592960
+	<p>
+	<ul>
+	<li>Moritz Blumenthal and Martin Uecker. <a href="https://index.mirasmart.com/ISMRM2021/PDFfiles/1754.html">Deep, Deep Learning with BART.</a> ISMRM Annual Meeting 2021, In Proc. Intl. Soc. Mag. Reson. Med. 29;1754 (2021)</li>
+	<li>Guanxiong Luo, Moritz Blumenthal, Martin Uecker. <a href="https://index.mirasmart.com/ISMRM2021/PDFfiles/1756.html">Using data-driven image priors for image reconstruction with BART.</a> ISMRM Annual Meeting 2021, In Proc. Intl. Soc. Mag. Reson. Med. 29;1756 (2021)</li>
+	<li>H. Christian M. Holme and Martin Uecker. <a href="https://index.mirasmart.com/ISMRM2021/PDFfiles/3768.html">Reproducibility meets Software Testing: Automatic Tests of Reproducible Publications Using BART.</a> ISMRM Annual Meeting 2021, In Proc. Intl. Soc. Mag. Reson. Med. 29;3768 (2021)</li>
+	<li>Martin Uecker. <a href="http://indexsmart.mirasmart.com/ISMRM2018/PDFfiles/2802.html">Machine Learning Using the BART Toolbox - Implementation of a Deep Convolutional Neural Network for Denoising.</a> Joint Annual Meeting ISMRM-ESMRMB, Paris 2018, In Proc. Intl. Soc. Mag. Reson. Med. 26;2802</li>
+	<li>Jonathan I Tamir, Frank Ong, Joseph Y Cheng, Martin Uecker, and Michael Lustig. <a href="https://www.gwdg.de/~muecker1/sedona16-bart.pdf">Generalized Magnetic Resonance Image Reconstruction using The Berkeley Advanced Reconstruction Toolbox</a>. <a href="http://www.ismrm.org/workshops/Data16/">ISMRM Workshop on Data Sampling and Image Reconstruction</a>, Sedona 2016
+	<li>Martin Uecker, Frank Ong, Jonathan I Tamir, Dara Bahri, Patrick Virtue, Joseph Y Cheng, Tao Zhang, and Michael Lustig.
+<a href="http://index.mirasmart.com/ismrm2015/PDFfiles/2486.pdf">Berkeley Advanced Reconstruction Toolbox</a>. Annual Meeting ISMRM, Toronto 2015, In Proc. Intl. Soc. Mag. Reson. Med. 23:2486
+	<li>Martin Uecker, Patrick Virtue, Frank Ong, Mark J. Murphy, Marcus T. Alley, Shreyas S. Vasanawala, and Michael Lustig. <a href="https://www.gwdg.de/~muecker1/toolbox.pdf">Software Toolbox and Programming Library for Compressed Sensing and Parallel Imaging</a>. <a href="https://www.ismrm.org/workshops/Data13/">ISMRM Workshop on Data Sampling and Image Reconstruction</a>, Sedona 2013
+	<li>Martin Uecker, Peng Lai, Mark J. Murphy, Patrick Virtue, Michael Elad, John M. Pauly, Shreyas S. Vasanawala, and Michael Lustig. <a href="http://onlinelibrary.wiley.com/doi/10.1002/mrm.24751/abstract">ESPIRiT - An Eigenvalue Approach to Autocalibrating Parallel MRI: Where SENSE meets GRAPPA</a>. Magnetic Resonance in Medicine, 71:990-1001 (2014)
+	</ul>
+	</small>
+
+  <p>
+
+  <h2 id="acknowledgements">Acknowledgements</h2>
+  <p>This work is supported by NIH Grant U24EB029240-01.</p>
+  <hr />
+  </p>
+
+
+      </div>
+    </center>
+  </body>
+</html>

--- a/publications.html
+++ b/publications.html
@@ -85,18 +85,15 @@
 	<p>
     <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
-
-
 <hr>
 
-
 <p>
+    <small>
 <div id="fig">
-  <small>
 <img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
 <strong>Figure:</strong> Simulated MRI images.
-	</small>
 </div>
+	</small>
 
 	<h2>Reproducible Research</h2>
 	<p>

--- a/publications.html
+++ b/publications.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">tutorials</a>,  <a href="./features.html">list of features</a>,  <a href="./publications.html">referencess & reproducibility</a>   </div>
+    <div>Quick links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
 <hr>
 <small>

--- a/publications.html
+++ b/publications.html
@@ -83,7 +83,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick Links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+    <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
 <hr>
 <small>

--- a/publications.html
+++ b/publications.html
@@ -85,6 +85,8 @@
 	<p>
     <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
+
+
 <hr>
 <small>
 

--- a/publications.html
+++ b/publications.html
@@ -88,12 +88,14 @@
 
 
 <hr>
-<small>
+
 
 <p>
 <div id="fig">
+  <small>
 <img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
 <strong>Figure:</strong> Simulated MRI images.
+	</small>
 </div>
 
 	<h2>Reproducible Research</h2>
@@ -129,7 +131,7 @@
 	<li>Martin Uecker, Patrick Virtue, Frank Ong, Mark J. Murphy, Marcus T. Alley, Shreyas S. Vasanawala, and Michael Lustig. <a href="https://www.gwdg.de/~muecker1/toolbox.pdf">Software Toolbox and Programming Library for Compressed Sensing and Parallel Imaging</a>. <a href="https://www.ismrm.org/workshops/Data13/">ISMRM Workshop on Data Sampling and Image Reconstruction</a>, Sedona 2013
 	<li>Martin Uecker, Peng Lai, Mark J. Murphy, Patrick Virtue, Michael Elad, John M. Pauly, Shreyas S. Vasanawala, and Michael Lustig. <a href="http://onlinelibrary.wiley.com/doi/10.1002/mrm.24751/abstract">ESPIRiT - An Eigenvalue Approach to Autocalibrating Parallel MRI: Where SENSE meets GRAPPA</a>. Magnetic Resonance in Medicine, 71:990-1001 (2014)
 	</ul>
-	</small>
+
 
   <p>
 

--- a/publications.html
+++ b/publications.html
@@ -87,7 +87,7 @@
 
 <hr>
 <small>
-  
+
 <p>
 <div id="fig">
 <img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>

--- a/publications.html
+++ b/publications.html
@@ -78,22 +78,20 @@
   </head>
   <body>
     <center>
-    <p>
-    <div id="body" align="left">
+	    <div id="body" align="left">
 	<img src="./imgs/banner.png" width="100%"><p>
-      <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
-	<p>
-    <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
+<h1>BART hands-on material: tutorials, workshops & webinars</h1>
+
+<div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
 
 <hr>
 
-<p>
 
+<p>
 <div id="fig">
 <img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
 <strong>Figure:</strong> Simulated MRI images.
 </div>
-
 
 	<h2>Reproducible Research</h2>
 	<p>

--- a/publications.html
+++ b/publications.html
@@ -83,17 +83,17 @@
 	<img src="./imgs/banner.png" width="100%"><p>
       <h1><a>Toolbox for Computational Magnetic Resonance Imaging</a></h1>
 	<p>
-    <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+    <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
 
 <hr>
 
 <p>
-    <small>
+
 <div id="fig">
 <img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
 <strong>Figure:</strong> Simulated MRI images.
 </div>
-	</small>
+
 
 	<h2>Reproducible Research</h2>
 	<p>

--- a/tutorials.html
+++ b/tutorials.html
@@ -82,15 +82,24 @@
 	<img src="./imgs/banner.png" width="100%"><p>
 <h1>BART hands-on material: tutorials, workshops & webinars</h1>
 
-<div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a></div>
+<div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">tutorials</a>,  <a href="./features.html">list of features</a>,  <a href="./publications.html">referencess & reproducibility</a>   </div>
 
 <hr>
+<small>
+
+<p>
+<div id="fig">
+<img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
+<strong>Figure:</strong> Simulated MRI images.
+</div>
+</small>
 
 <p>This webpage includes BART documentary and educational materials that were
   published over the last few years in tutorials, workshops and online webinars.
   It is organized by topics, starting with the basic material for new users, and moving to advanced materials.
 </p>
 
+<small>
 <hr>
 <h2>Table of contents </h2>
 <b>Getting Started with BART </b>
@@ -478,7 +487,8 @@ There are new tutorials from our Webinar which you can find in a <a class="githu
 </p>
 <p>
 Demo code and data: <a class="github" href="https://github.com/mrirecon/bart-workshop">GitHub repository</a>
-<p>
 
-</body>
+	</div>
+    </center>
+  </body>
 </html>

--- a/tutorials.html
+++ b/tutorials.html
@@ -84,8 +84,6 @@
 
 <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
-
-
 <hr>
 
 <small>

--- a/tutorials.html
+++ b/tutorials.html
@@ -100,7 +100,8 @@
   It is organized by topics, starting with the basic material for new users, and moving to advanced materials.
 </p>
 
-<small>
+
+
 <hr>
 <h2>Table of contents </h2>
 <b>Getting Started with BART </b>

--- a/tutorials.html
+++ b/tutorials.html
@@ -90,9 +90,9 @@
 <hr>
 <h2>Getting started with BART </h2>
 
-<h3 id="title1"> LINUX <1/h3>
+<h3 id="title1"> 1. Linux </h3>
 
-<h3 id="webinar-1">Using BART through the linux command line: webinar for new users </h3>
+<h4 id="webinar-1">Using BART through the linux command line: webinar for new users </h4>
 
 <p>This two-days webinar (from June 2020) introduced the concepts of working with BART through the linux command line.</p>
 <h4 id="day-1">Day 1</h4>
@@ -114,13 +114,16 @@
 <p><a href="https://www.youtube.com/playlist?list=PLDaugjrMfSRF0WhQ0nbcH4zeHWZPboGDY">Webinar #1 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar1">Webinar #1 Materials</a></p>
 
-<hr>
 
-<h3 id="webinar-1">Webinar for new users - python </h3>
-<p>This webinar (from july 2021) included a demo and hands-on exercise for working with BART in a python environment. It covered:</p>
+
+<h3 id="title1"> 2. Python </h3>
+
+
+<h4 id="webinar-1">Webinar for new users - python </h4>
+<p>The webinar we had on July 2021 includes a demo and hands-on exercise for working with BART in a python environment. It covers:</p>
 <ul>
-<li>How to use BART to create phantom data & subsample</li>
-<li>How to use BART for parallel MRI reconstruction</li>
+<li>How to create phantom data and subsampling masks in BART.</li>
+<li>How to use BART for parallel MRI reconstruction.</li>
 </ul>
 <p><a href="https://www.youtube.com/watch?v=8hqhnWkTsOo">Webinar #4 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar4">Webinar #4 Materials</a></p>
@@ -130,8 +133,8 @@
 <hr>
 <h2>Advanced Reconstruction with BART </h2>
 
-<h3 id="webinar-3">Webinar #3 (March 2021)</h3>
-<p>This webinar included demos and hands-on tutorials for:</p>
+<h3 id="webinar-3">1. Subspace constraint reconstruction & model-based reconstruction</h3>
+<p>The webinar of March 2021 included demos and hands-on tutorials for:</p>
 <ul>
 <li>Subspace-constrained reconstructions</li>
 <li>Analytical model-based phantom simulation</li>
@@ -139,33 +142,30 @@
 <p><a href="https://www.youtube.com/watch?v=lhhGVYQLx_8&list=PLDaugjrMfSRH4OmKg3XBj0TUL2ocOeJC8">Webinar #3 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar3">Webinar #3 Materials</a></p>
 
+<h3> 2. Model based reconstruction</h3>
+<p>The ISMRM 2021 BART software tutorial included an interactive demo on nonlinear model-based reconstruction for quantitative MRI (T1 mapping, water-fat separation)</p>
+<p><a href="  https://github.com/mrirecon/bart-workshop/blob/master/ismrm2021/model_based/bart_moba.ipynb">Jupyter notebook</a></p>
+
+
 
 <hr>
 <h2>Dynamic MRI Reconstruction with BART </h2>
 
-<h3>Webinar - Dynamic MRI & SENSE reproducibility challenge</h3>
-<p>This webinar included demos and hands-on tutorials for:</p>
+<h3>1. Introduction to dynamic MRI with BART</h3>
+<p>The webinar of Dec 2020 included demos and hands-on tutorials for:</p>
 <ul>
-<li>SENSE reproducibility challenge</li>
-<li>Advanced regularization methods for dynamic MRI data</li>
+<li>Dynamic (temporal sequence) MRI data loading, dimensions organization, and sensitivity maps computation.</li>
+<li>Image reconstruction using parallel-imaging-compressed-sensing (PICS), with advanced regularization methods suitable for dynamic MRI data.</li>
 </ul>
-This was webinar #2 in the 2020-2022 webinars series.
 <p><a href="https://www.youtube.com/playlist?list=PLDaugjrMfSRFj7WCtf9fuCeU2uN__4Tmi">Webinar #2 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar2">Webinar #2 Materials</a></p>
 
-<hr>
-<h3>ISMRM workshop - Dynamic Contrast Enhanced MRI reconstruction</h3>
+
+<h3>2. Dynamic Contrast Enhanced MRI reconstruction</h3>
 <p>The ISMRM 2016 software demo included a tutorial on dynamic axial-slice reconstruction with BART.</p>
 
-<p><a href="https://github.com/mrirecon/bart-workshop/tree/master/ismrm2016/pics-dce">jupyter notebook</a></p>
+<p><a href="https://github.com/mrirecon/bart-workshop/tree/master/ismrm2016/pics-dce">Jupyter notebook</a></p>
 
-
-
-
-<hr>
-<h2> Model based reconstruction with BART</h2>
-<p>The ISMRM 2021 BART software tutorial included an interactive demo on nonlinear model-based reconstruction for quantitative MRI (T1 mapping, water-fat separation)</p>
-<p><a href="  https://github.com/mrirecon/bart-workshop/blob/master/ismrm2021/model_based/bart_moba.ipynb">Jupyter notebook</a></p>
 
 
 <hr>
@@ -181,15 +181,24 @@ This was webinar #2 in the 2020-2022 webinars series.
 </ul>
 <p><a href="https://mrirecon.github.io/bart/ismrm21.html">ISMRM 2021 Materials</a></p>
 
+<hr>
+<h2>SENSE reproducibility challenge </h2>
+The BART solution of the SENSE reproducibility challenge (which was organized by the ISMRM) was covered in the webinar of Dec 2020:
+<p><a href="https://www.youtube.com/playlist?list=PLDaugjrMfSRFj7WCtf9fuCeU2uN__4Tmi">Webinar #2 Recordings</a></p>
+<p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar2">Webinar #2 Materials</a></p>
+
+
 
 <hr>
-<p>More useful links: our 2020-2022 webinars series can also be found here:</p>
+<h2>More useful links </h2>
+
+<p>Our 2020-2022 webinars series can also be found here:</p>
 <p><a href="https://www.youtube.com/channel/UCGZNJSJIx0UJLfbBHPSQ7aA/featured">Webinar Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars">Webinar Materials</a></p>
 
 
 <h2 id="acknowledgements">Acknowledgements</h2>
-<p>This work is supported by NIH Grant U24EB029240-01</p>
+<p>This work is supported by NIH Grant U24EB029240-01.</p>
 <hr />
 </p>
 	</div>

--- a/tutorials.html
+++ b/tutorials.html
@@ -82,7 +82,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
 <h1>BART hands-on material: tutorials, workshops & webinars</h1>
 
-<div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">tutorials</a>,  <a href="./features.html">list of features</a>,  <a href="./publications.html">referencess & reproducibility</a>   </div>
+<div>Quick links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
 <hr>
 <small>

--- a/tutorials.html
+++ b/tutorials.html
@@ -80,20 +80,19 @@
     <center>
 	    <div id="body" align="left">
 	<img src="./imgs/banner.png" width="100%"><p>
-<h1>BART tutorials, workshops & webinars</h1>
-<p>This webpage includes the full list of BART tutorials, demos and webinars that were given over the years.
-The matrerial is organized in an easy-to-difficult manner, such that the new-user tutorials appear first.
+<h1>BART documentation: tutorials, workshops & webinars</h1>
+<p>This webpage includes BART documentary and educational materials that were
+  published over the last few years in tutorials, workshops and online webinars.
+  It is organized by topics, starting with the basic material for new users, and moving to advanced materials.
 </p>
 
-<p>In addition, all the code and data for our 2020-2022 webinars series can be found here:</p>
-<p><a href="https://www.youtube.com/channel/UCGZNJSJIx0UJLfbBHPSQ7aA/featured">Webinar Recordings</a></p>
-<p><a href="https://github.com/mrirecon/bart-webinars">Webinar Materials</a></p>
 
 <hr>
 <h2>Getting started with BART </h2>
 
+<h3 id="title1"> LINUX <1/h3>
 
-<h3 id="webinar-1">Webinar for new users - linux </h3>
+<h3 id="webinar-1">Using BART through the linux command line: webinar for new users </h3>
 
 <p>This two-days webinar (from June 2020) introduced the concepts of working with BART through the linux command line.</p>
 <h4 id="day-1">Day 1</h4>
@@ -144,7 +143,6 @@ The matrerial is organized in an easy-to-difficult manner, such that the new-use
 <hr>
 <h2>Dynamic MRI Reconstruction with BART </h2>
 
-<hr>
 <h3>Webinar - Dynamic MRI & SENSE reproducibility challenge</h3>
 <p>This webinar included demos and hands-on tutorials for:</p>
 <ul>
@@ -161,8 +159,6 @@ This was webinar #2 in the 2020-2022 webinars series.
 
 <p><a href="https://github.com/mrirecon/bart-workshop/tree/master/ismrm2016/pics-dce">jupyter notebook</a></p>
 
-
-Reconstruct an axial slice of dynamic contrast enhanced (DCE) data
 
 
 
@@ -186,6 +182,10 @@ Reconstruct an axial slice of dynamic contrast enhanced (DCE) data
 <p><a href="https://mrirecon.github.io/bart/ismrm21.html">ISMRM 2021 Materials</a></p>
 
 
+<hr>
+<p>More useful links: our 2020-2022 webinars series can also be found here:</p>
+<p><a href="https://www.youtube.com/channel/UCGZNJSJIx0UJLfbBHPSQ7aA/featured">Webinar Recordings</a></p>
+<p><a href="https://github.com/mrirecon/bart-webinars">Webinar Materials</a></p>
 
 
 <h2 id="acknowledgements">Acknowledgements</h2>

--- a/tutorials.html
+++ b/tutorials.html
@@ -88,7 +88,7 @@
 
 
 <hr>
-<h2>Getting started with BART </h2>
+<h2>Getting Started with BART </h2>
 
 <h3 id="title1"> 1. Linux </h3>
 
@@ -127,6 +127,22 @@
 </ul>
 <p><a href="https://www.youtube.com/watch?v=8hqhnWkTsOo">Webinar #4 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar4">Webinar #4 Materials</a></p>
+
+
+<h3 id="title1"> 3. Python </h3>
+
+
+<h4 id="webinar-1">Getting started with BART - 45min tutorial</h4>
+<p>The ESMRMB MRI-Together 2021 workshop included a demo and hands-on exercise for working with BART in a python environment. It covers:</p>
+<ul>
+<li>How to set up an environment for BART.</li>
+<li>The BART command structure and data format.</li>
+<li>How to use Bitmasks to select dimensions.</li>
+<li>How to create a Cartesian k-space phantom.</li>
+<li>Example: Subspace T1 Mapping - including coil compression, trajectory generation and coil sensitivity estimation.</li>
+<li>Introduction to using BART for machine learning, including reconstruction with MoDL and variational networks.</li>
+</ul>
+<p><a href="https://github.com/mrirecon/bart-workshop/tree/master/mri_together_2021">ESMRMB 2021 material</a></p>
 
 
 
@@ -172,17 +188,41 @@
 <h2>Deep Learning with BART </h2>
 
 
+<h3 id="title1"> 1. Machine learning reconstruction with BART </h3>
 
-<h3> ISMRM 2021 tutorial on deep learning with BART (March 2021)</h3>
-<p>This webinar (given on April 2021) included demos and hands-on tutorials for:</p>
+<p>The ESMRMB MRI-Together 2021 workshop included a demo and hands-on exercise for working with BART in a python environment. It covers:</p>
+<ul>
+<li>Introduction to using BART for machine learning.</li>
+<li>Reconstruction with MoDL and Variational Networks.</li>
+</ul>
+<p><a href="https://github.com/mrirecon/bart-workshop/tree/master/mri_together_2021">ESMRMB 2021 material</a></p>
+
+
+<h3>2. Tensorflow and neural networks with BART</h3>
+
+<p>The ISMRM 2021 BART tutorial included demos and hands-on tutorials for:</p>
 <ul>
 <li>TensorFlow-Regularizer + BART Reconstruction</li>
+<p><a href="https://github.com/mrirecon/bart-workshop/blob/master/ismrm2021/bart_tensorflow/bart_tf.ipynb">jupyter notebook</a></p>
+
 <li>Neural networks with BART</li>
+<p><a href="https://github.com/mrirecon/bart-workshop/blob/master/ismrm2021/neural_networks/bart_neural_networks.ipynb
+">jupyter notebook</a></p>
+
+<li>How to run BART on Google Collab</li>
+<p><a href="https://github.com/mrirecon/bart-workshop/blob/master/ismrm2021/bart_on_colab/colab_gpu_tutorial.ipynb
+">jupyter notebook</a></p>
+
+
+
 </ul>
-<p><a href="https://mrirecon.github.io/bart/ismrm21.html">ISMRM 2021 Materials</a></p>
+<p><a href="https://mrirecon.github.io/bart/ismrm21.html">All ISMRM 2021 Materials</a></p>
+
+
+
 
 <hr>
-<h2>SENSE reproducibility challenge </h2>
+<h2>SENSE Reproducibility challenge </h2>
 The BART solution of the SENSE reproducibility challenge (which was organized by the ISMRM) was covered in the webinar of Dec 2020:
 <p><a href="https://www.youtube.com/playlist?list=PLDaugjrMfSRFj7WCtf9fuCeU2uN__4Tmi">Webinar #2 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar2">Webinar #2 Materials</a></p>

--- a/tutorials.html
+++ b/tutorials.html
@@ -110,12 +110,15 @@
 <li>Set up a build environment, compile, and run</li>
 <li>Add command-line parameter to existing tool</li>
 <li>Build a basic tool and system test</li>
-</ul>
+
 <p><a href="https://www.youtube.com/playlist?list=PLDaugjrMfSRF0WhQ0nbcH4zeHWZPboGDY">Webinar #1 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar1">Webinar #1 Materials</a></p>
+</ul>
+
 
 
 <h4 id="webinar-1">1.2 Bart workshop - ISMRM 2019</h4>
+<ul>
 The workshop tutorial included an introduction to the BART command-line tools.
 Topics covered:
 <li>The basic structure of BART commands</li>
@@ -129,10 +132,12 @@ Topics covered:
 
 <p><a href="https://github.com/mrirecon/bart-workshop/blob/master/ismrm2019/intro/intro.ipynb
 ">Workshop Material</a></p>
-
+</ul>
 
 <h4 id="webinar-1">1.3 Bart workshop - ISMRM 2016</h4>
-The workshop included a demo for:
+
+The workshop included demos for:
+<ul>
 <li>Creating multi-channel k-space data</li>
 <li>Using BART's Shepp Logan phantom</li>
 <li>Coil compression and image reconstruction</li>
@@ -140,21 +145,22 @@ The workshop included a demo for:
 <li>Using different regularization techniques</li>
 <p><a href="https://github.com/mrirecon/bart-workshop/tree/master/ismrm2016/pics-phantom
 ">Workshop Material</a></p>
-
+</ul>
 
 
 <h3 id="title1"> 2. Python </h3>
 
 
 <h4 id="webinar-1">2.1 Webinar for new users - python </h4>
-<p>The webinar we had on July 2021 includes a demo and hands-on exercise for working with BART in a python environment. It covers:</p>
 <ul>
+<p>The webinar we had on July 2021 includes a demo and hands-on exercise for working with BART in a python environment. It covers:</p>
+
 <li>How to create phantom data and subsampling masks in BART.</li>
 <li>How to use BART for parallel MRI reconstruction.</li>
-</ul>
+
 <p><a href="https://www.youtube.com/watch?v=8hqhnWkTsOo">Webinar #4 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar4">Webinar #4 Materials</a></p>
-
+</ul>
 
 <h4 id="webinar-1">2.2 Getting started with BART - 45min tutorial</h4>
 <p>The ESMRMB MRI-Together 2021 workshop included a demo and hands-on exercise for working with BART in a python environment. It covers:</p>
@@ -259,20 +265,39 @@ golden-ratio radial k-space sampling.
 <h2>Deep Learning with BART </h2>
 
 
-<h3 id="title1"> 1. Machine learning reconstruction with BART </h3>
-
-<p>The ESMRMB MRI-Together 2021 workshop included a demo and hands-on exercise for working with BART in a python environment. It covers:</p>
+<h3 id="title1"> 1. Introduction to machine learning reconstruction with BART </h3>
 <ul>
+<p>BART webinar #6 (March 1, 2022) included demos and hands-on tutorials for working with BART in a python environment. It covers:</p>
+
+<li>Introduction to using BART for machine learning.</li>
+<li>TensorFlow-regularization + BART Reconstruction.</li>
+<li>Examples for data pre-processing.</li>
+<li>Examples for training MoDL and a Variational Network with BART.</li>
+
+<p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar6">Webinar 6 material</a></p>
+
+<p><a href="https://www.youtube.com/watch?v=8ad_HQV87Tc">Webinar 6 recording</a></p>
+</ul>
+
+
+
+
+<h3 id="title1"> 2. Machine learning reconstruction with BART </h3>
+<ul>
+<p>The ESMRMB MRI-Together 2021 workshop included a demo and hands-on exercise for working with BART in a python environment. It covers:</p>
+
 <li>Introduction to using BART for machine learning.</li>
 <li>Reconstruction with MoDL and Variational Networks.</li>
-</ul>
+
 <p><a href="https://github.com/mrirecon/bart-workshop/tree/master/mri_together_2021">ESMRMB 2021 material</a></p>
+</ul>
 
 
-<h3>2. Tensorflow and neural networks with BART</h3>
 
-<p>The ISMRM 2021 BART tutorial included demos and hands-on tutorials for:</p>
+<h3>3. Tensorflow and neural networks with BART</h3>
 <ul>
+<p>The ISMRM 2021 BART tutorial included demos and hands-on tutorials for:</p>
+
 <li>TensorFlow-Regularizer + BART Reconstruction</li>
 <p><a href="https://github.com/mrirecon/bart-workshop/blob/master/ismrm2021/bart_tensorflow/bart_tf.ipynb">jupyter notebook</a></p>
 
@@ -284,16 +309,14 @@ golden-ratio radial k-space sampling.
 <p><a href="https://github.com/mrirecon/bart-workshop/blob/master/ismrm2021/bart_on_colab/colab_gpu_tutorial.ipynb
 ">jupyter notebook</a></p>
 
-
-
-</ul>
 <p><a href="https://mrirecon.github.io/bart/ismrm21.html">All ISMRM 2021 Materials</a></p>
-
+</ul>
 
 
 
 <hr>
 <h2>SENSE Reproducibility Challenge </h2>
+
 The BART solution of the SENSE reproducibility challenge (which was organized by the ISMRM) was covered in the webinar of Dec 2020:
 <p><a href="https://www.youtube.com/playlist?list=PLDaugjrMfSRFj7WCtf9fuCeU2uN__4Tmi">Webinar #2 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar2">Webinar #2 Materials</a></p>

--- a/tutorials.html
+++ b/tutorials.html
@@ -93,9 +93,9 @@ The matrerial is organized in an easy-to-difficult manner, such that the new-use
 <h2>Getting started with BART </h2>
 
 
-<h3 id="webinar-1">Webinar for new users (linux) (June 2020)</h3>
+<h3 id="webinar-1">Webinar for new users - linux </h3>
 
-<p>This two-days webinar introduced the concepts of working with BART through the linux command line.</p>
+<p>This two-days webinar (from June 2020) introduced the concepts of working with BART through the linux command line.</p>
 <h4 id="day-1">Day 1</h4>
 <ul>
 <li>Where to find docs, examples, and help</li>
@@ -117,8 +117,8 @@ The matrerial is organized in an easy-to-difficult manner, such that the new-use
 
 <hr>
 
-<h3 id="webinar-1">Webinar for new users (python) (June 2020)</h3>
-<p>This webinar included a demo and hands-on exercise for working with BART in a python environment. It covered:</p>
+<h3 id="webinar-1">Webinar for new users - python </h3>
+<p>This webinar (from july 2021) included a demo and hands-on exercise for working with BART in a python environment. It covered:</p>
 <ul>
 <li>How to use BART to create phantom data & subsample</li>
 <li>How to use BART for parallel MRI reconstruction</li>

--- a/tutorials.html
+++ b/tutorials.html
@@ -1,0 +1,161 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="de">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+    <title>BART Toolbox</title>
+    <style type="text/css">
+
+        BODY {
+		background: #292638;
+        }
+
+	h1, h2 {
+		font-family: 'PT Serif', serif;
+		border-bottom: 1px solid grey;
+		padding-bottom: 5px;
+	}
+
+	h1 {
+		border-top: 1px solid grey;
+		padding-top: 5px;
+		font-size: 30px;
+	}
+
+	h2 {
+		font-size: 24px;
+	}
+
+        div#index {
+                position: fixed;
+	        padding: 10px 15px 10px;
+		background: #FFFFFF;
+                width: 10%;
+        }
+
+        div#body {
+	        width: 60%;
+	        padding: 10px 15px 10px;
+		background: #FFFFFF;
+        }
+
+	.github {
+		padding: 3px;
+		color: white;
+		border-radius: 5px;
+		background: url(./imgs/GitHub-Mark-Light-64px.png) no-repeat 2% 50% #33f;
+		background-size: 12%;
+		padding-left: 25px;
+	}
+
+        div A {
+        }
+
+        div A:visited {
+        }
+
+        div A:hover {
+        }
+
+	.code {
+		border: 1px solid black;
+		background: #DDDDDD;
+	}
+
+	.alert {
+		border: 5px solid red;
+		padding-top: 5px;
+		font-size: 24px;
+	}
+
+	code {
+	}
+
+	img, object {
+        	max-width: 100%;
+	}
+
+    </style>
+  </head>
+  <body>
+    <center>
+	    <div id="body" align="left">
+	<img src="./imgs/banner.png" width="100%"><p>
+<h1>BART tutorials, workshops & webinars</h1>
+<p>This webpage includes the full list of BART tutorials, demos and webinars that were given over the years.
+The matrerial is organized in an easy-to-difficult manner, such that the new-user tutorials appear first.
+</p>
+
+<p>In addition, all the code and data for our 2020-2022 webinars series can be found here:</p>
+<p><a href="https://www.youtube.com/channel/UCGZNJSJIx0UJLfbBHPSQ7aA/featured">Webinar Recordings</a></p>
+<p><a href="https://github.com/mrirecon/bart-webinars">Webinar Materials</a></p>
+
+<hr>
+<h2>Getting started with BART </h2>
+
+
+<h3 id="webinar-1">Webinar for new users (linux) (June 2020)</h3>
+
+<p>This two-days webinar introduced the concepts of working with BART through the linux command line.</p>
+<h4 id="day-1">Day 1</h4>
+<ul>
+<li>Where to find docs, examples, and help</li>
+<li>Discussion of file format and dimensions</li>
+<li>Working with Command Line Interface (CLI) tools and Matlab/Python wrappers</li>
+<li>Data preprocessing</li>
+<li>Compressed Sensing and non-Cartesian MRI reconstruction</li>
+<li>GRASP-like MRI reconstruction</li>
+</ul>
+<h4 id="day-2">Day 2</h4>
+<ul>
+<li>Intro to the C-programming library</li>
+<li>Set up a build environment, compile, and run</li>
+<li>Add command-line parameter to existing tool</li>
+<li>Build a basic tool and system test</li>
+</ul>
+<p><a href="https://www.youtube.com/playlist?list=PLDaugjrMfSRF0WhQ0nbcH4zeHWZPboGDY">Webinar #1 Recordings</a></p>
+<p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar1">Webinar #1 Materials</a></p>
+
+<hr>
+
+<h3 id="webinar-1">Webinar for new users (python) (June 2020)</h3>
+<p>This webinar included a demo and hands-on exercise for working with BART in a python environment. It covered:</p>
+<ul>
+<li>How to use BART to create phantom data & subsample</li>
+<li>How to use BART for parallel MRI reconstruction</li>
+</ul>
+<p><a href="https://www.youtube.com/watch?v=8hqhnWkTsOo">Webinar #4 Recordings</a></p>
+<p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar4">Webinar #4 Materials</a></p>
+
+
+
+<hr>
+<h2>Advanced Reconstruction with BART </h2>
+
+<h3 id="webinar-3">Webinar #3 (March 2021)</h3>
+<p>This webinar included demos and hands-on tutorials for:</p>
+<ul>
+<li>Subspace-constrained reconstructions</li>
+<li>Analytical model-based phantom simulation</li>
+</ul>
+<p><a href="https://www.youtube.com/watch?v=lhhGVYQLx_8&list=PLDaugjrMfSRH4OmKg3XBj0TUL2ocOeJC8">Webinar #3 Recordings</a></p>
+<p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar3">Webinar #3 Materials</a></p>
+
+<hr>
+<h3 id="webinar-2">Webinar #2 - Dynamic MRI & SENSE reproducibility challenge</h3>
+<p>This webinar included demos and hands-on tutorials for:</p>
+<ul>
+<li>SENSE reproducibility challenge</li>
+<li>Advanced regularization methods for dynamic MRI data</li>
+</ul>
+<p><a href="https://www.youtube.com/playlist?list=PLDaugjrMfSRFj7WCtf9fuCeU2uN__4Tmi">Webinar #2 Recordings</a></p>
+<p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar2">Webinar #2 Materials</a></p>
+<hr>
+
+<h2 id="acknowledgements">Acknowledgements</h2>
+<p>This work is supported by NIH Grant U24EB029240-01</p>
+<hr />
+</p>
+	</div>
+    </center>
+  </body>
+</html>

--- a/tutorials.html
+++ b/tutorials.html
@@ -84,6 +84,8 @@
 
 <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
+
+
 <hr>
 
 <small>

--- a/tutorials.html
+++ b/tutorials.html
@@ -80,7 +80,7 @@
     <center>
 	    <div id="body" align="left">
 	<img src="./imgs/banner.png" width="100%"><p>
-<h1>BART hands-on material: tutorials, workshops & webinars</h1>
+<h1>BART Hands-on Material: Tutorials, Workshops & Webinars</h1>
 
 <div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
 
@@ -233,30 +233,6 @@ The workshop included demos for:
 ">Workshop Material</a></p>
 </ul>
 
-
-<h4>1.4 Quick Example</h4>
-<p>
-Perform ESPIRiT calibration and image reconstruction with
-l1-wavelet regularization:
-</p>
-<div class="code">
-<code>
-<p>
-&nbsp;$ bart ecalib kspace sensitivities<br>
-&nbsp;$ bart pics -l1 -r0.001 kspace sensitivities image_out
-</p>
-</code>
-</div>
-<p>
-A python-based image viewer (bartview.py) which can read the
-BART data format is included in the source repository.<br>
-</p>
-<p>
-An image viewer for Linux and Mac OS X can be found
-<a href="https://github.com/mrirecon/view">here</a>.
-</p>
-<p>
-You can try BART directly in your browser: <a href="https://mybinder.org/v2/gh/mrirecon/bart-binder/v0.7.00?filepath=example.ipynb"><img src="./imgs/binder.svg" alt="binder"></a>
 
 
 <hr>

--- a/tutorials.html
+++ b/tutorials.html
@@ -86,6 +86,78 @@
   It is organized by topics, starting with the basic material for new users, and moving to advanced materials.
 </p>
 
+<hr>
+<h2>Table of contents </h2>
+<b>Getting Started with BART </b>
+<br>
+<a href="#title1"> 1. Linux</a>
+<br>
+<a href="#title2"> 2. Python </a>
+<br>
+<a href="#title3"> 3. Matlab </a>
+
+<br>
+<br>
+
+<b>Non-Cartesian Reconstruction </b>
+<br>
+<a href="#title_Non_cart"> 1. Non-Cartesian SENSE reconstruction</a>
+<br>
+<a href="#title_GRASP"> 2. Non-Cartesian SENSE reconstruction</a>
+
+<br>
+<br>
+
+<b>Model-based Reconstruction </b>
+<br>
+<a href="#title_subspace"> 1. Subspace-constrained reconstruction</a>
+<br>
+<a href="#title_model_based"> 2. Model based reconstruction</a>
+
+<br>
+<br>
+
+<b>Dynamic MRI Reconstruction </b>
+<br>
+<a href="#title_intro_dynamic_MRI"> 1. Introduction to dynamic MRI reconstruction with BART</a>
+<br>
+<a href="#title_DCE"> 2. Dynamic Contrast Enhanced (DCE) MRI </a>
+
+
+<br>
+<br>
+
+<b>Deep Learning with BART </b>
+<br>
+<a href="#title1_intro_ML"> 1. Introduction to machine learning reconstruction with BART</a>
+<br>
+<a href="#title_ML"> 2. Machine learning reconstruction with BART </a>
+<br>
+<a href="#title_TensorFlow"> 3. TensorFlow and depp learning reconstruction with BART </a>
+
+
+<br>
+<br>
+
+<b>SENSE reproducibility challenge </b>
+<br>
+<a href="#title_SENSE_challenge"> The BART solution of the SENSE reproducibility challenge </a>
+
+
+<br>
+<br>
+
+<b>More useful links </b>
+<br>
+<a href="#title_2020_weibars"> The 2020-2022 webinar series </a>
+
+
+
+
+
+
+
+
 
 <hr>
 <h2>Getting Started with BART </h2>
@@ -118,9 +190,10 @@
 
 
 <h4 id="webinar-1">1.2 Bart workshop - ISMRM 2019</h4>
-<ul>
+
 The workshop tutorial included an introduction to the BART command-line tools.
 Topics covered:
+<ul>
 <li>The basic structure of BART commands</li>
 <li>displaying images</li>
 <li>using the BART phantom tool</li>
@@ -148,13 +221,13 @@ The workshop included demos for:
 </ul>
 
 
-<h3 id="title1"> 2. Python </h3>
+<h3 id="title2"> 2. Python </h3>
 
 
 <h4 id="webinar-1">2.1 Webinar for new users - python </h4>
-<ul>
-<p>The webinar we had on July 2021 includes a demo and hands-on exercise for working with BART in a python environment. It covers:</p>
 
+<p>The webinar we had on July 2021 includes a demo and hands-on exercise for working with BART in a python environment. It covers:</p>
+<ul>
 <li>How to create phantom data and subsampling masks in BART.</li>
 <li>How to use BART for parallel MRI reconstruction.</li>
 
@@ -171,13 +244,14 @@ The workshop included demos for:
 <li>How to create a Cartesian k-space phantom.</li>
 <li>Example: Subspace T1 Mapping - including coil compression, trajectory generation and coil sensitivity estimation.</li>
 <li>Introduction to using BART for machine learning, including reconstruction with MoDL and variational networks.</li>
-</ul>
-<p><a href="https://github.com/mrirecon/bart-workshop/tree/master/mri_together_2021">ESMRMB 2021 material</a></p>
 
+<p><a href="https://github.com/mrirecon/bart-workshop/tree/master/mri_together_2021">ESMRMB 2021 material</a></p>
+</ul>
 
 <h4 id="webinar-1">2.3 Data processing and computing g-factor for parallel imaging</h4>
 The ISMRM 2019 workshop included a tutorial that shows how to use the BART-Python
 interface for:
+<ul>
 <li>Loading data from h5 files</li>
 <li>Noise whitening</li>
 <li>Visualizing the sampling pattern</li>
@@ -185,12 +259,13 @@ interface for:
 <li>Computing g-factor for parallel imaging.</li>
 <p><a href="https://github.com/mrirecon/bart-workshop/blob/master/ismrm2019/gfactor-demo/gfactor-demo-real_data.ipynb
 ">Tutorial material</a></p>
+</ul>
 
 
 
 
 
-<h3 id="title1"> 3. Matlab </h3>
+<h3 id="title3"> 3. Matlab </h3>
 
 <h4 id="webinar-1">3.1 Inroduction to the BART-Matlab interface</h4>
 
@@ -209,11 +284,12 @@ followed by a retrospective Wave-CS reconstruction tool with the BART Matlab API
 <hr>
 <h2>Non-Cartesian Reconstruction with BART </h2>
 
-<h4>1. Non-Cartesian SENSE reconstruction</h4>
+<h3 > 1. Linux </h3>
+<h4 id="title_Non_cart">1. Non-Cartesian SENSE reconstruction</h4>
 The ISMRM 2019 workshop included a demo for non-Cartesian SENSE reconstruction
 <p><a href="https://github.com/mrirecon/bart-workshop/blob/master/ismrm2019/sense-recon/sense-recon.ipynb">Workshop Material</a></p>
 
-<h4>2. GRASP reconstruction</h4>
+<h4 id="title_GRASP">2. GRASP reconstruction</h4>
 The ISMRM 2016 workshop included a demo for GRASP reconstruction from
 golden-ratio radial k-space sampling.
 <p><a href="https://github.com/mrirecon/bart-workshop/tree/master/ismrm2016/grasp">Workshop Material</a></p>
@@ -222,7 +298,7 @@ golden-ratio radial k-space sampling.
 <hr>
 <h2>Model-based Reconstruction with BART </h2>
 
-<h3>1. Subspace constraint reconstruction & model-based reconstruction</h3>
+<h3 id="title_subspace">1. Subspace constraint reconstruction & model-based reconstruction</h3>
 <p>The webinar of March 2021 included demos and hands-on tutorials for:</p>
 <ul>
 <li>Subspace-constrained reconstructions</li>
@@ -231,7 +307,7 @@ golden-ratio radial k-space sampling.
 <p><a href="https://www.youtube.com/watch?v=lhhGVYQLx_8&list=PLDaugjrMfSRH4OmKg3XBj0TUL2ocOeJC8">Webinar #3 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar3">Webinar #3 Materials</a></p>
 
-<h3>2. Model based reconstruction</h3>
+<h3 id="title_model_based">2. Model based reconstruction</h3>
 <p>The ISMRM 2021 BART software tutorial included an interactive demo on nonlinear model-based reconstruction for quantitative MRI (T1 mapping, water-fat separation)</p>
 <p><a href="  https://github.com/mrirecon/bart-workshop/blob/master/ismrm2021/model_based/bart_moba.ipynb">Jupyter notebook</a></p>
 
@@ -240,7 +316,7 @@ golden-ratio radial k-space sampling.
 <hr>
 <h2>Dynamic MRI Reconstruction with BART </h2>
 
-<h3>1. Introduction to dynamic MRI with BART</h3>
+<h3 id="title_intro_dynamic_MRI">1. Introduction to dynamic MRI with BART</h3>
 <p>The webinar of Dec 2020 included demos and hands-on tutorials for:</p>
 <ul>
 <li>Dynamic (temporal sequence) MRI data loading, dimensions organization, and sensitivity maps computation.</li>
@@ -250,7 +326,7 @@ golden-ratio radial k-space sampling.
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar2">Webinar #2 Materials</a></p>
 
 
-<h3>2. Dynamic Contrast Enhanced (DCE) MRI reconstruction</h3>
+<h3 id="title_DCE">2. Dynamic Contrast Enhanced (DCE) MRI reconstruction</h3>
 <p>The ISMRM 2016 software demo included a tutorial on dynamic axial-slice reconstruction with BART.</p>
 
 <p><a href="https://github.com/mrirecon/bart-workshop/tree/master/ismrm2016/pics-dce">Jupyter notebook</a></p>
@@ -265,10 +341,10 @@ golden-ratio radial k-space sampling.
 <h2>Deep Learning with BART </h2>
 
 
-<h3 id="title1"> 1. Introduction to machine learning reconstruction with BART </h3>
-<ul>
-<p>BART webinar #6 (March 1, 2022) included demos and hands-on tutorials for working with BART in a python environment. It covers:</p>
+<h3 id="title1_intro_ML"> 1. Introduction to machine learning reconstruction with BART </h3>
 
+<p>BART webinar #6 (March 1, 2022) included demos and hands-on tutorials for working with BART in a python environment. It covers:</p>
+<ul>
 <li>Introduction to using BART for machine learning.</li>
 <li>TensorFlow-regularization + BART Reconstruction.</li>
 <li>Examples for data pre-processing.</li>
@@ -282,10 +358,10 @@ golden-ratio radial k-space sampling.
 
 
 
-<h3 id="title1"> 2. Machine learning reconstruction with BART </h3>
-<ul>
-<p>The ESMRMB MRI-Together 2021 workshop included a demo and hands-on exercise for working with BART in a python environment. It covers:</p>
+<h3 id="title_ML"> 2. Machine learning reconstruction with BART </h3>
 
+<p>The ESMRMB MRI-Together 2021 workshop included a demo and hands-on exercise for working with BART in a python environment. It covers:</p>
+<ul>
 <li>Introduction to using BART for machine learning.</li>
 <li>Reconstruction with MoDL and Variational Networks.</li>
 
@@ -294,10 +370,10 @@ golden-ratio radial k-space sampling.
 
 
 
-<h3>3. Tensorflow and neural networks with BART</h3>
-<ul>
-<p>The ISMRM 2021 BART tutorial included demos and hands-on tutorials for:</p>
+<h3 id="title_TensorFlow">3. Tensorflow and neural networks with BART</h3>
 
+<p>The ISMRM 2021 BART tutorial included demos and hands-on tutorials for:</p>
+<ul>
 <li>TensorFlow-Regularizer + BART Reconstruction</li>
 <p><a href="https://github.com/mrirecon/bart-workshop/blob/master/ismrm2021/bart_tensorflow/bart_tf.ipynb">jupyter notebook</a></p>
 
@@ -308,16 +384,18 @@ golden-ratio radial k-space sampling.
 <li>How to run BART on Google Collab</li>
 <p><a href="https://github.com/mrirecon/bart-workshop/blob/master/ismrm2021/bart_on_colab/colab_gpu_tutorial.ipynb
 ">jupyter notebook</a></p>
-
-<p><a href="https://mrirecon.github.io/bart/ismrm21.html">All ISMRM 2021 Materials</a></p>
 </ul>
+<p><a href="https://mrirecon.github.io/bart/ismrm21.html">All ISMRM 2021 Materials</a></p>
+
 
 
 
 <hr>
 <h2>SENSE Reproducibility Challenge </h2>
 
-The BART solution of the SENSE reproducibility challenge (which was organized by the ISMRM) was covered in the webinar of Dec 2020:
+<h4 id="title_SENSE_challenge"> The BART solution of the SENSE reproducibility challenge </h4>
+
+The challenge was organized by the ISMRM. The BART solution was presented in our Dec 2020 webinar:
 <p><a href="https://www.youtube.com/playlist?list=PLDaugjrMfSRFj7WCtf9fuCeU2uN__4Tmi">Webinar #2 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar2">Webinar #2 Materials</a></p>
 
@@ -326,7 +404,9 @@ The BART solution of the SENSE reproducibility challenge (which was organized by
 <hr>
 <h2>More useful links </h2>
 
-<p>Our 2020-2022 webinars series can also be found here:</p>
+
+<h4 id="title_2020_weibars"> Our 2020-2022 webinars series can also be found here: </h4>
+
 <p><a href="https://www.youtube.com/channel/UCGZNJSJIx0UJLfbBHPSQ7aA/featured">Webinar Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars">Webinar Materials</a></p>
 

--- a/tutorials.html
+++ b/tutorials.html
@@ -82,7 +82,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
 <h1>BART hands-on material: tutorials, workshops & webinars</h1>
 
-<div>Quick Links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+<div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
 <hr>
 

--- a/tutorials.html
+++ b/tutorials.html
@@ -464,12 +464,21 @@ The challenge was organized by the ISMRM. The BART solution was presented in our
 <p><a href="https://www.youtube.com/channel/UCGZNJSJIx0UJLfbBHPSQ7aA/featured">Webinar Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars">Webinar Materials</a></p>
 
+<hr>
+<h3>Webinars & workshops material in chornological order </h3>
 
-<h2 id="acknowledgements">Acknowledgements</h2>
-<p>This work is supported by NIH Grant U24EB029240-01.</p>
-<hr />
+<p>
+There are new tutorials from our Webinar which you can find in a <a class="github" href="https://github.com/mrirecon/bart-webinars">GitHub repository</a>.
 </p>
-	</div>
-    </center>
-  </body>
+
+<p> <b>ISMRM 2021</b> As part of the ISMRM 2021 meeting, we gave a <a href="./ismrm21.html">demo of the new features of BART related to non-linear model-based reconstruction and deep learning integration.</a>
+</p>
+<p>
+<b>ISMRM 2016</b> The toolbox was presented at the <a href="http://www.ismrm.org/workshops/Data16/">ISMRM 2016 Data Sampling and Image Reconstruction Workshop</a>. This material was created for BART version 0.3.00 and later versions might have minor differences. Please check the README included with each release for up-to-date installation instructions.
+</p>
+<p>
+Demo code and data: <a class="github" href="https://github.com/mrirecon/bart-workshop">GitHub repository</a>
+<p>
+
+</body>
 </html>

--- a/tutorials.html
+++ b/tutorials.html
@@ -85,6 +85,7 @@
 <div>Quick Links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
 <hr>
+
 <small>
 
 <p>

--- a/tutorials.html
+++ b/tutorials.html
@@ -100,8 +100,6 @@
   It is organized by topics, starting with the basic material for new users, and moving to advanced materials.
 </p>
 
-
-
 <hr>
 <h2>Table of contents </h2>
 <b>Getting Started with BART </b>

--- a/tutorials.html
+++ b/tutorials.html
@@ -80,7 +80,7 @@
     <center>
 	    <div id="body" align="left">
 	<img src="./imgs/banner.png" width="100%"><p>
-<h1>BART documentation: tutorials, workshops & webinars</h1>
+<h1>BART hands-on material: tutorials, workshops & webinars</h1>
 <p>This webpage includes BART documentary and educational materials that were
   published over the last few years in tutorials, workshops and online webinars.
   It is organized by topics, starting with the basic material for new users, and moving to advanced materials.
@@ -186,7 +186,14 @@ interface for:
 
 <h3 id="title1"> 3. Matlab </h3>
 
-<h4 id="webinar-1">Using the BART-Matlab interface</h4>
+<h4 id="webinar-1">3.1 Inroduction to the BART-Matlab interface</h4>
+
+The first webinar of 2020 included a demo for using the BART Matlab API.
+<p><a href="https://www.youtube.com/playlist?list=PLDaugjrMfSRF0WhQ0nbcH4zeHWZPboGDY">Webinar #1 Recordings</a></p>
+<p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar1">Webinar #1 Materials</a></p>
+
+
+<h4 id="webinar-1">3.2 Using the BART-Matlab interface</h4>
 
 The ISMRM 2016 workshop included a demo for performing a Wave-CAIPI reconstruction
 followed by a retrospective Wave-CS reconstruction tool with the BART Matlab API.
@@ -207,7 +214,7 @@ golden-ratio radial k-space sampling.
 
 
 <hr>
-<h2>Advanced Reconstruction with BART </h2>
+<h2>Model-based Reconstruction with BART </h2>
 
 <h3>1. Subspace constraint reconstruction & model-based reconstruction</h3>
 <p>The webinar of March 2021 included demos and hands-on tutorials for:</p>
@@ -237,11 +244,15 @@ golden-ratio radial k-space sampling.
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar2">Webinar #2 Materials</a></p>
 
 
-<h3>2. Dynamic Contrast Enhanced MRI reconstruction</h3>
+<h3>2. Dynamic Contrast Enhanced (DCE) MRI reconstruction</h3>
 <p>The ISMRM 2016 software demo included a tutorial on dynamic axial-slice reconstruction with BART.</p>
 
 <p><a href="https://github.com/mrirecon/bart-workshop/tree/master/ismrm2016/pics-dce">Jupyter notebook</a></p>
 
+<h4>3. GRASP reconstruction</h4>
+The ISMRM 2016 workshop included a demo for GRASP reconstruction from
+golden-ratio radial k-space sampling.
+<p><a href="https://github.com/mrirecon/bart-workshop/tree/master/ismrm2016/grasp">Workshop Material</a></p>
 
 
 <hr>
@@ -282,7 +293,7 @@ golden-ratio radial k-space sampling.
 
 
 <hr>
-<h2>SENSE Reproducibility challenge </h2>
+<h2>SENSE Reproducibility Challenge </h2>
 The BART solution of the SENSE reproducibility challenge (which was organized by the ISMRM) was covered in the webinar of Dec 2020:
 <p><a href="https://www.youtube.com/playlist?list=PLDaugjrMfSRFj7WCtf9fuCeU2uN__4Tmi">Webinar #2 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar2">Webinar #2 Materials</a></p>

--- a/tutorials.html
+++ b/tutorials.html
@@ -81,6 +81,11 @@
 	    <div id="body" align="left">
 	<img src="./imgs/banner.png" width="100%"><p>
 <h1>BART hands-on material: tutorials, workshops & webinars</h1>
+
+<div>Quick links: <a href="./Download & Installation.html">Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a></div>
+
+<hr>
+
 <p>This webpage includes BART documentary and educational materials that were
   published over the last few years in tutorials, workshops and online webinars.
   It is organized by topics, starting with the basic material for new users, and moving to advanced materials.
@@ -90,7 +95,7 @@
 <h2>Table of contents </h2>
 <b>Getting Started with BART </b>
 <br>
-<a href="#title1"> 1. Linux</a>
+<a href="#title1"> 1. Linux/unix terminal</a>
 <br>
 <a href="#title2"> 2. Python </a>
 <br>
@@ -159,14 +164,15 @@
 
 
 
+
 <hr>
 <h2>Getting Started with BART </h2>
 
-<h3 id="title1"> 1. Linux </h3>
+<h3 id="title1"> 1. Terminal </h3>
 
-<h4 id="webinar-1">1.1 Using BART through the linux command line: webinar for new users (2020)</h4>
+<h4 id="webinar-1">1.1 Using BART through the linux/unix command line: webinar for new users (2020)</h4>
 
-<p>This two-days webinar (from June 2020) introduced the concepts of working with BART through the linux command line.</p>
+<p>This two-days webinar (from June 2020) introduced the concepts of working with BART through the linux/unix command line.</p>
 <h4 id="day-1">Day 1</h4>
 <ul>
 <li>Where to find docs, examples, and help</li>
@@ -221,6 +227,32 @@ The workshop included demos for:
 </ul>
 
 
+<h4>1.4 Quick Example</h4>
+<p>
+Perform ESPIRiT calibration and image reconstruction with
+l1-wavelet regularization:
+</p>
+<div class="code">
+<code>
+<p>
+&nbsp;$ bart ecalib kspace sensitivities<br>
+&nbsp;$ bart pics -l1 -r0.001 kspace sensitivities image_out
+</p>
+</code>
+</div>
+<p>
+A python-based image viewer (bartview.py) which can read the
+BART data format is included in the source repository.<br>
+</p>
+<p>
+An image viewer for Linux and Mac OS X can be found
+<a href="https://github.com/mrirecon/view">here</a>.
+</p>
+<p>
+You can try BART directly in your browser: <a href="https://mybinder.org/v2/gh/mrirecon/bart-binder/v0.7.00?filepath=example.ipynb"><img src="./imgs/binder.svg" alt="binder"></a>
+
+
+<hr>
 <h3 id="title2"> 2. Python </h3>
 
 
@@ -263,9 +295,31 @@ interface for:
 
 
 
-
+<hr>
 
 <h3 id="title3"> 3. Matlab </h3>
+
+
+<h4>Matlab Interface and Examples</h4>
+<p>
+The toolbox can also be used in combination with Matlab/Octave.
+</p>
+<div class="code">
+<code>
+<p>
+&nbsp;&gt;&gt;&nbsp;sensitivities = bart('ecalib', kspace);<br>
+&nbsp;&gt;&gt;&nbsp;image_out = bart('pics -l1 -r0.001', kspace, sensitivities);
+</code>
+</div>
+<p>
+More examples where the tools are called
+directly from Matlab can be found <a href="./examples.html">here</a>.
+<p>
+Matlab code and data: <a class="github" href="https://github.com/mikgroup/espirit-matlab-examples">GitHub repository</a>
+<p>
+A Matlab-based image viewer which works well with BART is <a href="http://www.biomednmr.mpg.de/index.php?option=com_content&task=view&id=137&Itemid=43">arrayShow</a> by Tilman Sumpf.
+
+
 
 <h4 id="webinar-1">3.1 Inroduction to the BART-Matlab interface</h4>
 
@@ -284,7 +338,7 @@ followed by a retrospective Wave-CS reconstruction tool with the BART Matlab API
 <hr>
 <h2>Non-Cartesian Reconstruction with BART </h2>
 
-<h3 > 1. Linux </h3>
+<h3 > 1. Linux/unix terminal </h3>
 <h4 id="title_Non_cart">1. Non-Cartesian SENSE reconstruction</h4>
 The ISMRM 2019 workshop included a demo for non-Cartesian SENSE reconstruction
 <p><a href="https://github.com/mrirecon/bart-workshop/blob/master/ismrm2019/sense-recon/sense-recon.ipynb">Workshop Material</a></p>

--- a/tutorials.html
+++ b/tutorials.html
@@ -92,7 +92,7 @@
 
 <h3 id="title1"> 1. Linux </h3>
 
-<h4 id="webinar-1">Using BART through the linux command line: webinar for new users </h4>
+<h4 id="webinar-1">1.1 Using BART through the linux command line: webinar for new users (2020)</h4>
 
 <p>This two-days webinar (from June 2020) introduced the concepts of working with BART through the linux command line.</p>
 <h4 id="day-1">Day 1</h4>
@@ -115,11 +115,38 @@
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar1">Webinar #1 Materials</a></p>
 
 
+<h4 id="webinar-1">1.2 Bart workshop - ISMRM 2019</h4>
+The workshop tutorial included an introduction to the BART command-line tools.
+Topics covered:
+<li>The basic structure of BART commands</li>
+<li>displaying images</li>
+<li>using the BART phantom tool</li>
+<li>viewing data dimensions</li>
+<li>Bitmasks</li>
+<li>Low-pass filtering</li>
+<li>Reconstruction of multi-coil data</li>
+<li>Reconstruction with parallel imaging compressed sensing (PICS)</li>
+
+<p><a href="https://github.com/mrirecon/bart-workshop/blob/master/ismrm2019/intro/intro.ipynb
+">Workshop Material</a></p>
+
+
+<h4 id="webinar-1">1.3 Bart workshop - ISMRM 2016</h4>
+The workshop included a demo for:
+<li>Creating multi-channel k-space data</li>
+<li>Using BART's Shepp Logan phantom</li>
+<li>Coil compression and image reconstruction</li>
+<li>Generating ESPIRIT sensitivity maps using BART's ecalib tool</li>
+<li>Using different regularization techniques</li>
+<p><a href="https://github.com/mrirecon/bart-workshop/tree/master/ismrm2016/pics-phantom
+">Workshop Material</a></p>
+
+
 
 <h3 id="title1"> 2. Python </h3>
 
 
-<h4 id="webinar-1">Webinar for new users - python </h4>
+<h4 id="webinar-1">2.1 Webinar for new users - python </h4>
 <p>The webinar we had on July 2021 includes a demo and hands-on exercise for working with BART in a python environment. It covers:</p>
 <ul>
 <li>How to create phantom data and subsampling masks in BART.</li>
@@ -129,10 +156,7 @@
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar4">Webinar #4 Materials</a></p>
 
 
-<h3 id="title1"> 3. Python </h3>
-
-
-<h4 id="webinar-1">Getting started with BART - 45min tutorial</h4>
+<h4 id="webinar-1">2.2 Getting started with BART - 45min tutorial</h4>
 <p>The ESMRMB MRI-Together 2021 workshop included a demo and hands-on exercise for working with BART in a python environment. It covers:</p>
 <ul>
 <li>How to set up an environment for BART.</li>
@@ -145,11 +169,47 @@
 <p><a href="https://github.com/mrirecon/bart-workshop/tree/master/mri_together_2021">ESMRMB 2021 material</a></p>
 
 
+<h4 id="webinar-1">2.3 Data processing and computing g-factor for parallel imaging</h4>
+The ISMRM 2019 workshop included a tutorial that shows how to use the BART-Python
+interface for:
+<li>Loading data from h5 files</li>
+<li>Noise whitening</li>
+<li>Visualizing the sampling pattern</li>
+<li>Reconstruction</li>
+<li>Computing g-factor for parallel imaging.</li>
+<p><a href="https://github.com/mrirecon/bart-workshop/blob/master/ismrm2019/gfactor-demo/gfactor-demo-real_data.ipynb
+">Tutorial material</a></p>
+
+
+
+
+
+<h3 id="title1"> 3. Matlab </h3>
+
+<h4 id="webinar-1">Using the BART-Matlab interface</h4>
+
+The ISMRM 2016 workshop included a demo for performing a Wave-CAIPI reconstruction
+followed by a retrospective Wave-CS reconstruction tool with the BART Matlab API.
+<p><a href="https://github.com/mrirecon/bart-workshop/tree/master/ismrm2016/wave-cs">Workshop Material</a></p>
+
+
+<hr>
+<h2>Non-Cartesian Reconstruction with BART </h2>
+
+<h4>1. Non-Cartesian SENSE reconstruction</h4>
+The ISMRM 2019 workshop included a demo for non-Cartesian SENSE reconstruction
+<p><a href="https://github.com/mrirecon/bart-workshop/blob/master/ismrm2019/sense-recon/sense-recon.ipynb">Workshop Material</a></p>
+
+<h4>2. GRASP reconstruction</h4>
+The ISMRM 2016 workshop included a demo for GRASP reconstruction from
+golden-ratio radial k-space sampling.
+<p><a href="https://github.com/mrirecon/bart-workshop/tree/master/ismrm2016/grasp">Workshop Material</a></p>
+
 
 <hr>
 <h2>Advanced Reconstruction with BART </h2>
 
-<h3 id="webinar-3">1. Subspace constraint reconstruction & model-based reconstruction</h3>
+<h3>1. Subspace constraint reconstruction & model-based reconstruction</h3>
 <p>The webinar of March 2021 included demos and hands-on tutorials for:</p>
 <ul>
 <li>Subspace-constrained reconstructions</li>
@@ -158,7 +218,7 @@
 <p><a href="https://www.youtube.com/watch?v=lhhGVYQLx_8&list=PLDaugjrMfSRH4OmKg3XBj0TUL2ocOeJC8">Webinar #3 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar3">Webinar #3 Materials</a></p>
 
-<h3> 2. Model based reconstruction</h3>
+<h3>2. Model based reconstruction</h3>
 <p>The ISMRM 2021 BART software tutorial included an interactive demo on nonlinear model-based reconstruction for quantitative MRI (T1 mapping, water-fat separation)</p>
 <p><a href="  https://github.com/mrirecon/bart-workshop/blob/master/ismrm2021/model_based/bart_moba.ipynb">Jupyter notebook</a></p>
 

--- a/tutorials.html
+++ b/tutorials.html
@@ -82,23 +82,21 @@
 	<img src="./imgs/banner.png" width="100%"><p>
 <h1>BART hands-on material: tutorials, workshops & webinars</h1>
 
-<div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+<div>Quick Links: <a href="./index.html">Home</a>, <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of Features</a>,  <a href="./publications.html">References & Reproducibility</a>   </div>
 
 <hr>
 
-<small>
 
 <p>
 <div id="fig">
 <img src="./imgs/bart8.png" alt="bart logo reconstructed from k-space" width="100%"><p>
 <strong>Figure:</strong> Simulated MRI images.
 </div>
-</small>
 
-<p>This webpage includes BART documentary and educational materials that were
+This webpage includes BART documentary and educational materials that were
   published over the last few years in tutorials, workshops and online webinars.
   It is organized by topics, starting with the basic material for new users, and moving to advanced materials.
-</p>
+
 
 <hr>
 <h2>Table of contents </h2>

--- a/tutorials.html
+++ b/tutorials.html
@@ -140,16 +140,53 @@ The matrerial is organized in an easy-to-difficult manner, such that the new-use
 <p><a href="https://www.youtube.com/watch?v=lhhGVYQLx_8&list=PLDaugjrMfSRH4OmKg3XBj0TUL2ocOeJC8">Webinar #3 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar3">Webinar #3 Materials</a></p>
 
+
 <hr>
-<h3 id="webinar-2">Webinar #2 - Dynamic MRI & SENSE reproducibility challenge</h3>
+<h2>Dynamic MRI Reconstruction with BART </h2>
+
+<hr>
+<h3>Webinar - Dynamic MRI & SENSE reproducibility challenge</h3>
 <p>This webinar included demos and hands-on tutorials for:</p>
 <ul>
 <li>SENSE reproducibility challenge</li>
 <li>Advanced regularization methods for dynamic MRI data</li>
 </ul>
+This was webinar #2 in the 2020-2022 webinars series.
 <p><a href="https://www.youtube.com/playlist?list=PLDaugjrMfSRFj7WCtf9fuCeU2uN__4Tmi">Webinar #2 Recordings</a></p>
 <p><a href="https://github.com/mrirecon/bart-webinars/tree/master/webinar2">Webinar #2 Materials</a></p>
+
 <hr>
+<h3>ISMRM workshop - Dynamic Contrast Enhanced MRI reconstruction</h3>
+<p>The ISMRM 2016 software demo included a tutorial on dynamic axial-slice reconstruction with BART.</p>
+
+<p><a href="https://github.com/mrirecon/bart-workshop/tree/master/ismrm2016/pics-dce">jupyter notebook</a></p>
+
+
+Reconstruct an axial slice of dynamic contrast enhanced (DCE) data
+
+
+
+<hr>
+<h2> Model based reconstruction with BART</h2>
+<p>The ISMRM 2021 BART software tutorial included an interactive demo on nonlinear model-based reconstruction for quantitative MRI (T1 mapping, water-fat separation)</p>
+<p><a href="  https://github.com/mrirecon/bart-workshop/blob/master/ismrm2021/model_based/bart_moba.ipynb">Jupyter notebook</a></p>
+
+
+<hr>
+<h2>Deep Learning with BART </h2>
+
+
+
+<h3> ISMRM 2021 tutorial on deep learning with BART (March 2021)</h3>
+<p>This webinar (given on April 2021) included demos and hands-on tutorials for:</p>
+<ul>
+<li>TensorFlow-Regularizer + BART Reconstruction</li>
+<li>Neural networks with BART</li>
+</ul>
+<p><a href="https://mrirecon.github.io/bart/ismrm21.html">ISMRM 2021 Materials</a></p>
+
+
+
 
 <h2 id="acknowledgements">Acknowledgements</h2>
 <p>This work is supported by NIH Grant U24EB029240-01</p>

--- a/tutorials.html
+++ b/tutorials.html
@@ -82,7 +82,7 @@
 	<img src="./imgs/banner.png" width="100%"><p>
 <h1>BART hands-on material: tutorials, workshops & webinars</h1>
 
-<div>Quick links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
+<div>Quick Links: <a href="./installation.html">Download & Installation</a>, <a href="./tutorials.html">Tutorials</a>,  <a href="./features.html">List of features</a>,  <a href="./publications.html">Referencess & Reproducibility</a>   </div>
 
 <hr>
 <small>


### PR DESCRIPTION
BART hands-on material page (tutorials.html) added. It includes links to all the recent demos, webinars and git repos (2016-2022).