### PR TITLE
RPM-Build for Fedora 36

### DIFF
--- a/pkg/rpm/bart.spec
+++ b/pkg/rpm/bart.spec
@@ -36,6 +36,7 @@ echo {{{ bart_git_version }}} > version.txt
 
 %endif
 
+export LDFLAGS="$LDFLAGS -Wl,--no-as-needed"
 make PARALLEL=1
 make doc/commands.txt
 

--- a/pkg/rpm/libbart-devel.spec
+++ b/pkg/rpm/libbart-devel.spec
@@ -23,6 +23,7 @@ This package provides headers and static libraries.
 {{{ git_setup_macro dir_name=libbart-devel }}}
 
 %build
+export LDFLAGS="$LDFLAGS -Wl,--no-as-needed"
 make PARALLEL=1
 
 %install


### PR DESCRIPTION
Fedora 36 defines some default LDFLAGS for every build, including `-Wl,--as-needed`.
Somehow this results in undefined cblas symbols in the final linking step.
I appended `-Wl,--no-as-needed` to LDFLAGS for now to be able to build rpms for Fedora 36.