### PR TITLE
adjoint nufft example used wrong dcf

### DIFF
--- a/scripts/radial_dcf.sh
+++ b/scripts/radial_dcf.sh
@@ -30,7 +30,7 @@ bart spow -- -0.5 density sqdcf
 
 # adjoint nufft
 bart fmac dcf ksp ksp_filt2
-bart nufft -a traj ksp_filt img_filt2
+bart nufft -a traj ksp_filt2 img_filt2
 
 # one channel all ones sensititty
 bart ones 3 256 256 1 sens


### PR DESCRIPTION
looks like a typo, but img_filt2 used ksp_filt (Ram-Lak dcf) instead of ksp_filt2 (gridding-ungridding dcf)