### PR TITLE
Fix incorrect handling of keyword arguments

### DIFF
--- a/python/bart.py
+++ b/python/bart.py
@@ -45,7 +45,7 @@ def bart(nargout, cmd, *args, **kwargs):
     for idx in range(nargin):
         cfl.writecfl(infiles[idx], args[idx])
 
-    args_kw = ["--" if len(kw)>1 else "-" + kw for kw in kwargs]
+    args_kw = [("--" if len(kw)>1 else "-") + kw for kw in kwargs]
     infiles_kw = [name + 'in' + kw for kw in kwargs]
     for idx, kw in enumerate(kwargs):
         cfl.writecfl(infiles_kw[idx], kwargs[kw])


### PR DESCRIPTION
This PR solves a bug introduced in 4ded5814aa6f6147ebc525ce82b131730e2725eb

Incorrect grouping of expressions meant that if the keyword argument had more than 1 character, the code would append the double dashes, but not the keyword argument. As far as I can tell, there is no _current_ tool that would run into this problem, but I believe it's good manners to fix the bug I introduced.

Previous behavior:
```
kwargs = ['hello', 'w']
args_kw = ["--" if len(kw) > 1 else "-" + kw for kw in kwargs]
print(args_kw)
```

Output: `['--', '-w']`

Fixed in this PR:
```
kwargs = ['hello', 'w']
args_kw = [("--" if len(kw) > 1 else "-") + kw for kw in kwargs]
print(args_kw)
```

Output: `['--hello', '-w']`