### PR TITLE
set DEBUG_LEVEL for tests that read from stdout

### DIFF
--- a/tests/estdelay.mk
+++ b/tests/estdelay.mk
@@ -4,7 +4,7 @@ tests/test-estdelay: estdelay traj phantom nrmse
 	$(TOOLDIR)/traj -D -q1.5:1:-0.5 -r -y8 t.ra						;\
 	$(TOOLDIR)/traj -D -r -y8 t0.ra								;\
 	$(TOOLDIR)/phantom -k -t t.ra k.ra							;\
-	$(TOOLDIR)/traj -D -q`$(TOOLDIR)/estdelay t0.ra k.ra` -r -y8 t2.ra			;\
+	$(TOOLDIR)/traj -D -q`DEBUG_LEVEL=0 $(TOOLDIR)/estdelay t0.ra k.ra` -r -y8 t2.ra	;\
 	$(TOOLDIR)/nrmse -t 0.00001 t.ra t2.ra							;\
 	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
 	touch $@
@@ -14,18 +14,18 @@ tests/test-estdelay-dccen: estdelay traj phantom nrmse
 	$(TOOLDIR)/traj -D -q1.5:1.:-0.5 -r -y8 -c t.ra						;\
 	$(TOOLDIR)/phantom -k -t t.ra k.ra							;\
 	$(TOOLDIR)/traj -D -r -y8 -c t0.ra							;\
-	$(TOOLDIR)/traj -D -q`$(TOOLDIR)/estdelay t0.ra k.ra` -r -y8 -c t2.ra			;\
+	$(TOOLDIR)/traj -D -q`DEBUG_LEVEL=0 $(TOOLDIR)/estdelay t0.ra k.ra` -r -y8 -c t2.ra	;\
 	$(TOOLDIR)/nrmse -t 0.0001 t.ra t2.ra							;\
 	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
 	touch $@
 
 tests/test-estdelay-dccen-scale: estdelay traj phantom nrmse
-	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)						;\
-	$(TOOLDIR)/traj -D -q1.5:1:-0.5 -r -y8 -o2. -c t.ra					;\
-	$(TOOLDIR)/phantom -k -t t.ra k.ra							;\
-	$(TOOLDIR)/traj -D -r -y8 -o2. -c t0.ra							;\
-	$(TOOLDIR)/traj -D -q`$(TOOLDIR)/estdelay t0.ra k.ra` -r -y8 -o2. -c t2.ra		;\
-	$(TOOLDIR)/nrmse -t 0.0001 t.ra t2.ra							;\
+	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)							;\
+	$(TOOLDIR)/traj -D -q1.5:1:-0.5 -r -y8 -o2. -c t.ra						;\
+	$(TOOLDIR)/phantom -k -t t.ra k.ra								;\
+	$(TOOLDIR)/traj -D -r -y8 -o2. -c t0.ra								;\
+	$(TOOLDIR)/traj -D -q`DEBUG_LEVEL=0 $(TOOLDIR)/estdelay t0.ra k.ra` -r -y8 -o2. -c t2.ra	;\
+	$(TOOLDIR)/nrmse -t 0.0001 t.ra t2.ra								;\
 	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
 	touch $@
 
@@ -34,7 +34,7 @@ tests/test-estdelay-transverse: estdelay traj phantom nrmse
 	$(TOOLDIR)/traj -D -O -q1.5:1:-0.5 -r -y8 t.ra						;\
 	$(TOOLDIR)/traj -D -r -y8 t0.ra								;\
 	$(TOOLDIR)/phantom -k -t t.ra k.ra							;\
-	$(TOOLDIR)/traj -D -O -q`$(TOOLDIR)/estdelay t0.ra k.ra` -r -y8 t2.ra			;\
+	$(TOOLDIR)/traj -D -O -q`DEBUG_LEVEL=0 $(TOOLDIR)/estdelay t0.ra k.ra` -r -y8 t2.ra	;\
 	$(TOOLDIR)/nrmse -t 0.0011 t.ra t2.ra							;\
 	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
 	touch $@
@@ -44,18 +44,18 @@ tests/test-estdelay-coils: estdelay traj phantom nrmse
 	$(TOOLDIR)/traj -G -q0.3:-0.1:0.2 -y5 -o2. -c t.ra					;\
 	$(TOOLDIR)/traj -G -r -y5 -o2. n.ra							;\
 	$(TOOLDIR)/phantom -s8 -k -t t.ra k.ra							;\
-	$(TOOLDIR)/traj -G -q`$(TOOLDIR)/estdelay n.ra k.ra` -y5 -o2. t2.ra			;\
+	$(TOOLDIR)/traj -G -q`DEBUG_LEVEL=0 $(TOOLDIR)/estdelay n.ra k.ra` -y5 -o2. t2.ra	;\
 	$(TOOLDIR)/nrmse -t 0.004 t.ra t2.ra							;\
 	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
 	touch $@
 
 tests/test-estdelay-ring-scale: estdelay traj phantom nrmse
-	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)						;\
-	$(TOOLDIR)/traj -D -r -q0.3:0.1:0.2 -O -c -y5 -o2. t.ra					;\
-	$(TOOLDIR)/traj -D -c -r -y5 -o2. n.ra							;\
-	$(TOOLDIR)/phantom -k -t t.ra k.ra							;\
-	$(TOOLDIR)/traj -D -r -q`$(TOOLDIR)/estdelay -R n.ra k.ra` -O -y5 -o2. -c t2.ra		;\
-	$(TOOLDIR)/nrmse -t 0.0001 t.ra t2.ra							;\
+	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)							;\
+	$(TOOLDIR)/traj -D -r -q0.3:0.1:0.2 -O -c -y5 -o2. t.ra						;\
+	$(TOOLDIR)/traj -D -c -r -y5 -o2. n.ra								;\
+	$(TOOLDIR)/phantom -k -t t.ra k.ra								;\
+	$(TOOLDIR)/traj -D -r -q`DEBUG_LEVEL=0 $(TOOLDIR)/estdelay -R n.ra k.ra` -O -y5 -o2. -c t2.ra	;\
+	$(TOOLDIR)/nrmse -t 0.0001 t.ra t2.ra								;\
 	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
 	touch $@
 
@@ -64,7 +64,7 @@ tests/test-estdelay-ring-uncen: estdelay traj phantom nrmse
 	$(TOOLDIR)/traj -D -r -q0.3:0.1:0.2 -y5 -o2. t.ra					;\
 	$(TOOLDIR)/traj -D -r -y5 -o2. n.ra							;\
 	$(TOOLDIR)/phantom -k -t t.ra k.ra							;\
-	$(TOOLDIR)/traj -D -r -q`$(TOOLDIR)/estdelay -R n.ra k.ra` -y5 -o2. t2.ra		;\
+	$(TOOLDIR)/traj -D -r -q`DEBUG_LEVEL=0 $(TOOLDIR)/estdelay -R n.ra k.ra` -y5 -o2. t2.ra	;\
 	$(TOOLDIR)/nrmse -t 0.002 t.ra t2.ra							;\
 	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
 	touch $@
@@ -74,7 +74,7 @@ tests/test-estdelay-ring: estdelay traj phantom nrmse
 	$(TOOLDIR)/traj -D -r -q0.3:0.1:0.2 -c -y5 t.ra						;\
 	$(TOOLDIR)/traj -D -c -r -y5 n.ra							;\
 	$(TOOLDIR)/phantom -s8 -k -t t.ra k.ra							;\
-	$(TOOLDIR)/traj -D -r -q`$(TOOLDIR)/estdelay -R n.ra k.ra` -y5 -c t2.ra			;\
+	$(TOOLDIR)/traj -D -r -q`DEBUG_LEVEL=0 $(TOOLDIR)/estdelay -R n.ra k.ra` -y5 -c t2.ra	;\
 	$(TOOLDIR)/nrmse -t 0.0035 t.ra t2.ra							;\
 	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
 	touch $@
@@ -85,33 +85,33 @@ tests/test-estdelay-scale: estdelay traj phantom nrmse
 	$(TOOLDIR)/traj -D -q1.5:1:-0.5 -r -y8 -o2. t.ra					;\
 	$(TOOLDIR)/traj -D -r -y8 -o2. t0.ra							;\
 	$(TOOLDIR)/phantom -k -t t.ra k.ra							;\
-	$(TOOLDIR)/traj -D -q`$(TOOLDIR)/estdelay t0.ra k.ra` -r -y8 -o2. t2.ra			;\
+	$(TOOLDIR)/traj -D -q`DEBUG_LEVEL=0 $(TOOLDIR)/estdelay t0.ra k.ra` -r -y8 -o2. t2.ra	;\
 	$(TOOLDIR)/nrmse -t 0.0001 t.ra t2.ra							;\
 	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
 	touch $@
 
 tests/test-estdelay-asym: estdelay traj phantom nrmse extract
-	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)						;\
-	$(TOOLDIR)/traj -D -q1.5:1.:-0.5 -r -y8 -x128 t.ra					;\
-	$(TOOLDIR)/phantom -k -t t.ra k.ra							;\
-	$(TOOLDIR)/traj -D -r -y8 -x128 t0.ra							;\
-	$(TOOLDIR)/extract 1 1 128 k.ra kb.ra 							;\
-	$(TOOLDIR)/extract 1 1 128 t0.ra t0b.ra 						;\
-	$(TOOLDIR)/traj -D -q`$(TOOLDIR)/estdelay t0b.ra kb.ra` -r -y8 -x128 t2.ra		;\
-	$(TOOLDIR)/nrmse -t 0.0001 t.ra t2.ra							;\
+	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)							;\
+	$(TOOLDIR)/traj -D -q1.5:1.:-0.5 -r -y8 -x128 t.ra						;\
+	$(TOOLDIR)/phantom -k -t t.ra k.ra								;\
+	$(TOOLDIR)/traj -D -r -y8 -x128 t0.ra								;\
+	$(TOOLDIR)/extract 1 1 128 k.ra kb.ra 								;\
+	$(TOOLDIR)/extract 1 1 128 t0.ra t0b.ra 							;\
+	$(TOOLDIR)/traj -D -q`DEBUG_LEVEL=0 $(TOOLDIR)/estdelay t0b.ra kb.ra` -r -y8 -x128 t2.ra	;\
+	$(TOOLDIR)/nrmse -t 0.0001 t.ra t2.ra								;\
 	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
 	touch $@
 
 
 tests/test-estdelay-dccen-asym: estdelay traj phantom nrmse extract
-	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)						;\
-	$(TOOLDIR)/traj -D -q1.5:1.:-0.5 -r -y8 -c -x128 t.ra					;\
-	$(TOOLDIR)/phantom -k -t t.ra k.ra							;\
-	$(TOOLDIR)/traj -D -r -y8 -c -x128 t0.ra						;\
-	$(TOOLDIR)/extract 1 1 128 k.ra kb.ra 							;\
-	$(TOOLDIR)/extract 1 1 128 t0.ra t0b.ra 						;\
-	$(TOOLDIR)/traj -D -q`$(TOOLDIR)/estdelay t0b.ra kb.ra` -r -y8 -c -x128 t2.ra		;\
-	$(TOOLDIR)/nrmse -t 0.0001 t.ra t2.ra							;\
+	set -e; mkdir $(TESTS_TMP) ; cd $(TESTS_TMP)							;\
+	$(TOOLDIR)/traj -D -q1.5:1.:-0.5 -r -y8 -c -x128 t.ra						;\
+	$(TOOLDIR)/phantom -k -t t.ra k.ra								;\
+	$(TOOLDIR)/traj -D -r -y8 -c -x128 t0.ra							;\
+	$(TOOLDIR)/extract 1 1 128 k.ra kb.ra 								;\
+	$(TOOLDIR)/extract 1 1 128 t0.ra t0b.ra 							;\
+	$(TOOLDIR)/traj -D -q`DEBUG_LEVEL=0 $(TOOLDIR)/estdelay t0b.ra kb.ra` -r -y8 -c -x128 t2.ra	;\
+	$(TOOLDIR)/nrmse -t 0.0001 t.ra t2.ra								;\
 	rm *.ra ; cd .. ; rmdir $(TESTS_TMP)
 	touch $@
 


### PR DESCRIPTION
tests that use output from stdout should explicitly set DEBUG_LEVEL=0 (in my opinion)