### PR TITLE
fix broken macports build with gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,8 @@ endif
 
 ifeq ($(BUILDTYPE), MacOSX)
 	MACPORTS ?= 1
+else
+	MACPORTS ?= 0
 endif
 
 
@@ -460,8 +462,14 @@ CFLAGS += -fopenmp
 CXXFLAGS += -fopenmp
 NVCCFLAGS += -Xcompiler -fopenmp
 else
+ifeq ($(MACPORTS),1)
+CFLAGS += -fopenmp
+CXXFLAGS += -fopenmp
+NVCCFLAGS += -Xcompiler -fopenmp
+else
 LDFLAGS += "-L/usr/local/opt/libomp/lib" -lomp
 CPPFLAGS += "-I/usr/local/opt/libomp/include" -Xclang -fopenmp
+endif
 endif
 else
 CFLAGS += -Wno-unknown-pragmas


### PR DESCRIPTION
Fixes Macports build issue introduced in b40a5c1c1112f1c947aac2fdf275d7fe590ac8bf