### PR TITLE
Fix undeclared loop variable in png_write_anyrgb

### DIFF
--- a/src/misc/png.c
+++ b/src/misc/png.c
@@ -60,7 +60,9 @@ static int png_write_anyrgb(const char* name, int w, int h, int nbytes, bool rgb
 	row_ptrs = xmalloc((size_t)((long)sizeof(png_bytep) * h));
 	row_size = png_get_rowbytes(structp, infop);
 
-	for (int i = 0; i < h; i++)
+	int i;
+
+	for (i = 0; i < h; i++)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-qual"
 		row_ptrs[i] = (png_bytep)buf + row_size * i;


### PR DESCRIPTION
This fixes a GCC error when building on Ubuntu 22.04 with GCC 11+:
`i` undeclared (first use in this function)

The loop variable i is now declared outside the for loop for compatibility across GCC and Clang compilers.