### PR TITLE
Readme updates for MacOS compilation

### DIFF
--- a/README
+++ b/README
@@ -141,7 +141,7 @@ To install the required libraries on  Fedora 39/40 run:
 
 ### 2.1.2. Mac OS X
 
-BART is supported on Intel-based and ARM-based Macs. Xcode is also required. For
+BART is supported on Intel-based and ARM-based Macs. Xcode CommandLineTools is also required (install with: $ xcode-select --install). For
 ARM-based Macs, it is recommended to use gcc12 or higher.
 
 Using MacPorts (http://www.macports.org/):


### PR DESCRIPTION
Had issues compiling for MacOS.  It seems macOS no longer includes libBlocksRuntime in system libraries by default. These fixes helped me.